### PR TITLE
some tweaks to update auth flow, fixed email / password signup & login

### DIFF
--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -49,17 +49,18 @@ async function routes(app) {
       try {
         await Auth0.createUser(token, payload);
       } catch (err) {
+        // 409 means CONFLICT, e.g. user exists
         if (err.statusCode !== 409) {
           return reply.code(err.statusCode).send(err);
         }
       }
-
       const accessToken = await Auth0.authenticate("password", {
         password: req.body.password,
         scope: "openid",
         username: req.body.email,
       });
-      return reply.send({ token: accessToken });
+
+      return { token: accessToken };
     },
   );
 }


### PR DESCRIPTION
just some small tweaks to the auth code
have double checked everything and updated the settings on Auth0, it's working now and we just need to update the react app to call the right API call (for email/password signup and login).

few small things i would like to change but for now seems to work ok. 

Maybe we could have separate routes for /signup and /login with username / password, so it doesn't  call the `createUser` on every attempt to call `/api/auth/authenticate`. 

Also, sending the error info from Auth0 to the client seems like a bad idea, so would like to improve the error handling a bit.
