### PR TITLE
Add missing / to node_modules mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "3000:3000"
     volumes:
       - ./client:/app
-      - /app/node_modules
+      - /app/node_modules/
     working_dir: /app
     stdin_open: true
     tty: true


### PR DESCRIPTION
Noticed a missing `/` at the end of the client `node_modules` mount. The trailing slash is critical for it to be excluded from the container mount, and also not have it modified by any `npm install` run on the host: https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder#comment71220422_37898591