### PR TITLE
Use alpine/slim base images

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 WORKDIR '/app'
 COPY package.json package-lock.json ./
 RUN npm install

--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 WORKDIR '/app'
 COPY . .
 RUN npm install

--- a/geo-service/Dockerfile
+++ b/geo-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
This cut down the image sizes by more than half. Should speed up builds.