### PR TITLE
Feed Frontend: show airtable data and truncate text

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2579,6 +2579,21 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
+    "acorn-dynamic-import": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+      "requires": {
+        "acorn": "^4.0.3"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+        }
+      }
+    },
     "acorn-globals": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
@@ -2700,6 +2715,16 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -4178,6 +4203,15 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -8492,6 +8526,11 @@
         "side-channel": "^1.0.2"
       }
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -8783,8 +8822,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -9377,8 +9415,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9396,13 +9433,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9415,18 +9450,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9529,8 +9561,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9540,7 +9571,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9553,20 +9583,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9583,7 +9610,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -9639,8 +9665,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -9665,8 +9690,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9676,7 +9700,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9745,8 +9768,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9776,7 +9798,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9794,7 +9815,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9833,13 +9853,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -10377,6 +10395,11 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -10957,6 +10980,11 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
       "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -14676,6 +14704,296 @@
         "react-tween-state": "^0.1.5"
       }
     },
+    "react-read-more-read-less": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-read-more-read-less/-/react-read-more-read-less-1.0.7.tgz",
+      "integrity": "sha512-xgwAxvg+SjYLjaxuP/GW548pKS++RGJzUmADEa28eKuBtX2zz4M31It8CvaU7JeR4IT4Hd/TXVnN0aCqv4NHNQ==",
+      "requires": {
+        "react": "^16.2.0",
+        "webpack": "^2.6.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+        },
+        "big.js": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "enhanced-resolve": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+          "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "object-assign": "^4.0.1",
+            "tapable": "^0.2.7"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "tapable": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.9.tgz",
+          "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A=="
+        },
+        "webpack": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
+          "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
+          "requires": {
+            "acorn": "^5.0.0",
+            "acorn-dynamic-import": "^2.0.0",
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.1.1",
+            "async": "^2.1.2",
+            "enhanced-resolve": "^3.3.0",
+            "interpret": "^1.0.0",
+            "json-loader": "^0.5.4",
+            "json5": "^0.5.1",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^0.2.16",
+            "memory-fs": "~0.4.1",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": "^2.0.0",
+            "source-map": "^0.5.3",
+            "supports-color": "^3.1.0",
+            "tapable": "~0.2.5",
+            "uglify-js": "^2.8.27",
+            "watchpack": "^1.3.1",
+            "webpack-sources": "^1.0.1",
+            "yargs": "^6.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    },
     "react-redux": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
@@ -15325,6 +15643,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "rimraf": {
       "version": "2.6.3",
@@ -17566,6 +17892,55 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
     "unfetch": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
@@ -17963,8 +18338,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -17982,13 +18356,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -18001,18 +18373,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -18115,8 +18484,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -18126,7 +18494,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -18139,20 +18506,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -18169,7 +18533,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -18225,8 +18588,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -18251,8 +18613,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -18262,7 +18623,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -18331,8 +18691,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -18362,7 +18721,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -18380,7 +18738,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -18419,13 +18776,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -18947,8 +19302,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -18966,13 +19320,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -18985,18 +19337,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19099,8 +19448,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19110,7 +19458,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -19123,20 +19470,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19153,7 +19497,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -19209,8 +19552,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -19235,8 +19577,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -19246,7 +19587,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19315,8 +19655,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19346,7 +19685,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19364,7 +19702,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -19403,13 +19740,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -19816,10 +20151,20 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
     },
     "workbox-background-sync": {
       "version": "4.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^16.13.1",
     "react-load-script": "0.0.6",
     "react-moment": "^0.9.7",
+    "react-read-more-read-less": "^1.0.7",
     "react-redux": "^7.2.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -1,46 +1,48 @@
-import React, { useState } from "react";
-import { Modal, Card, WhiteSpace } from "antd-mobile";
+import React from "react";
+// import React, { useState } from "react";
+import { Card, WhiteSpace } from "antd-mobile";
+// import { Modal, Card, WhiteSpace } from "antd-mobile";
 import PostCard from "./PostCard";
-import PostSocial from "./PostSocial";
-import Comments from "./Comments";
+// import PostSocial from "./PostSocial";
+// import Comments from "./Comments";
 import FilterTag from "../../components/Tag/FilterTag";
 import StatusIcon from "../Icon/status-indicator";
-import AutoSize from "../../components/Input/AutoSize";
+// import AutoSize from "../../components/Input/AutoSize";
 
 export default ({ post }) => {
-  const [showComments, setShowComments] = useState(false);
-  const [copied, setCopied] = useState(false);
+  // const [showComments, setShowComments] = useState(false);
+  // const [copied, setCopied] = useState(false);
   // mock API to test functionality
-  const [liked, setLiked] = useState(false);
-  const [shared, setShared] = useState(false);
-  const [comment, setComment] = useState("");
-  const [fakeLikes, setFakeLikes] = useState(post.numLikes);
-  const [fakeComments, setFakeComments] = useState(post.numComments);
-  const [fakeShares, setFakeShares] = useState(post.numShares);
+  // const [liked, setLiked] = useState(false);
+  // const [shared, setShared] = useState(false);
+  // const [comment, setComment] = useState("");
+  // const [fakeLikes, setFakeLikes] = useState(post.numLikes);
+  // const [fakeComments, setFakeComments] = useState(post.numComments);
+  // const [fakeShares, setFakeShares] = useState(post.numShares);
 
-  const handleComment = (e) => {
-    e.preventDefault();
-    const testNewComment = {
-      _id: 10,
-      name: "Guest User",
-      numLikes: 0,
-      children: [],
-      comment,
-    };
-    post.comments.push(testNewComment); // not good but mocking API and testing UI
-    setFakeComments(fakeComments + 1);
-    setShowComments(true);
-    setComment("");
-  };
+  // const handleComment = (e) => {
+  //   e.preventDefault();
+  //   const testNewComment = {
+  //     _id: 10,
+  //     name: "Guest User",
+  //     numLikes: 0,
+  //     children: [],
+  //     comment,
+  //   };
+  //   post.comments.push(testNewComment); // not good but mocking API and testing UI
+  //   setFakeComments(fakeComments + 1);
+  //   setShowComments(true);
+  //   setComment("");
+  // };
 
   const renderHeader = (
     <Card.Header
-      title={post.author}
-      thumb={post.photoUrl}
+      title="Guest User"
+      thumb="https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSeKU8QNW5Iv71hpiQiVkKPuv6lFvZYC6WBP0oBLM61s9d4KFOq&usqp=CAU"
       extra={
         <span>
           <StatusIcon className="status-icon" />
-          {post.location}
+          {post["Region"]}
         </span>
       }
     />
@@ -48,84 +50,88 @@ export default ({ post }) => {
 
   const renderContent = (
     <Card.Body>
-      <h1>{post.title}</h1>
-      <p className="post-description">{post.description}</p>
+      <h1>{post["Post Title"]}</h1>
+      <p className="post-description">{post["Description"]}</p>
     </Card.Body>
   );
 
-  const renderTags = (
-    <Card.Body>
-      {post.tags.map((tag, idx) => (
-        <FilterTag label={tag} selected={false} disabled={true} key={idx} />
-      ))}
-    </Card.Body>
-  );
+  const renderTags = () => {
+    if (post["Type"]) {
+      return (
+        <Card.Body>
+          {post["Type"].map((tag, idx) => (
+            <FilterTag label={tag} selected={false} disabled={true} key={idx} />
+          ))}
+        </Card.Body>
+      );
+    }
+  };
 
-  const renderViewMore = (
-    <Card.Body>
-      <span className="view-more">View More</span>
-    </Card.Body>
-  );
+  // const renderViewMore = (
+  //   <Card.Body>
+  //     <span className="view-more">View More</span>
+  //   </Card.Body>
+  // );
 
-  const renderComments = (
-    <Card.Body>
-      <AutoSize
-        placeholder={"Write a comment..."}
-        onPressEnter={handleComment}
-        onChange={(e) => setComment(e.target.value)}
-        value={comment}
-      />
-      {showComments ? <Comments comments={post.comments} /> : ""}
-    </Card.Body>
-  );
+  // const renderComments = (
+  //   <Card.Body>
+  //     <AutoSize
+  //       placeholder={"Write a comment..."}
+  //       onPressEnter={handleComment}
+  //       onChange={(e) => setComment(e.target.value)}
+  //       value={comment}
+  //     />
+  //     {showComments ? <Comments comments={post.comments} /> : ""}
+  //   </Card.Body>
+  // );
 
-  const renderSocialIcons = (
-    <Card.Body>
-      <PostSocial
-        url={post.url}
-        liked={liked}
-        shared={shared}
-        showComments={showComments}
-        numLikes={fakeLikes}
-        numComments={fakeComments}
-        numShares={fakeShares}
-        setShowComments={() => setShowComments(!showComments)}
-        onCopyLink={() => {
-          if (!shared) setFakeShares(fakeShares + 1);
-          setShared(true);
-          return setCopied(!copied);
-        }}
-        likePost={() => {
-          liked ? setFakeLikes(fakeLikes - 1) : setFakeLikes(fakeLikes + 1);
-          return setLiked(!liked);
-        }}
-      />
-    </Card.Body>
-  );
+  // const renderSocialIcons = (
+  //   <Card.Body>
+  //     <PostSocial
+  //       url={post.url}
+  //       liked={liked}
+  //       shared={shared}
+  //       showComments={showComments}
+  //       numLikes={fakeLikes}
+  //       numComments={fakeComments}
+  //       numShares={fakeShares}
+  //       setShowComments={() => setShowComments(!showComments)}
+  //       onCopyLink={() => {
+  //         if (!shared) setFakeShares(fakeShares + 1);
+  //         setShared(true);
+  //         return setCopied(!copied);
+  //       }}
+  //       likePost={() => {
+  //         liked ? setFakeLikes(fakeLikes - 1) : setFakeLikes(fakeLikes + 1);
+  //         return setLiked(!liked);
+  //       }}
+  //     />
+  //   </Card.Body>
+  // );
 
-  const renderShareModal = (
-    <Modal
-      onClose={() => setCopied(!copied)}
-      maskClosable={true}
-      closable={true}
-      visible={copied}
-      transparent
-    >
-      <h1 style={{ color: "black" }}>Link Copied!</h1>
-    </Modal>
-  );
+  // const renderShareModal = (
+  //   <Modal
+  //     onClose={() => setCopied(!copied)}
+  //     maskClosable={true}
+  //     closable={true}
+  //     visible={copied}
+  //     transparent
+  //   >
+  //     <h1 style={{ color: "black" }}>Link Copied!</h1>
+  //   </Modal>
+  // );
 
   return (
     <PostCard>
       {renderHeader}
       <WhiteSpace size="md" />
-      {renderTags}
+      {renderTags()}
       <WhiteSpace />
       {renderContent}
-      {renderViewMore}
-      {renderSocialIcons}
-      {renderComments}
-      {renderShareModal}
+      {/* {renderViewMore} */}
+      {/* {renderSocialIcons} */}
+      {/* {renderComments} */}
+      {/* {renderShareModal} */}
     </PostCard>
   );
 };

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactReadMoreReadLess from "react-read-more-read-less";
 // import React, { useState } from "react";
 import { Card, WhiteSpace } from "antd-mobile";
 // import { Modal, Card, WhiteSpace } from "antd-mobile";
@@ -48,30 +49,36 @@ export default ({ post }) => {
     />
   );
 
-  const renderContent = (
+  const renderContent = post["Description"] ? (
     <Card.Body>
       <h1>{post["Post Title"]}</h1>
-      <p className="post-description">{post["Description"]}</p>
+      <p className="post-description">
+        <ReactReadMoreReadLess
+          charLimit={200}
+          readMoreText={"View more"}
+          readLessText={"View less"}
+          readMoreClassName="view-more"
+          readLessClassName="view-more"
+          readMoreStyle={{ display: "block", marginTop: "2rem" }}
+          readLessStyle={{ display: "block", marginTop: "2rem" }}
+        >
+          {post["Description"]}
+        </ReactReadMoreReadLess>
+      </p>
     </Card.Body>
+  ) : (
+    ""
   );
 
-  const renderTags = () => {
-    if (post["Type"]) {
-      return (
-        <Card.Body>
-          {post["Type"].map((tag, idx) => (
-            <FilterTag label={tag} selected={false} disabled={true} key={idx} />
-          ))}
-        </Card.Body>
-      );
-    }
-  };
-
-  // const renderViewMore = (
-  //   <Card.Body>
-  //     <span className="view-more">View More</span>
-  //   </Card.Body>
-  // );
+  const renderTags = post["Type"] ? (
+    <Card.Body>
+      {post["Type"].map((tag, idx) => (
+        <FilterTag label={tag} selected={false} disabled={true} key={idx} />
+      ))}
+    </Card.Body>
+  ) : (
+    ""
+  );
 
   // const renderComments = (
   //   <Card.Body>
@@ -125,10 +132,9 @@ export default ({ post }) => {
     <PostCard>
       {renderHeader}
       <WhiteSpace size="md" />
-      {renderTags()}
+      {renderTags}
       <WhiteSpace />
       {renderContent}
-      {/* {renderViewMore} */}
       {/* {renderSocialIcons} */}
       {/* {renderComments} */}
       {/* {renderShareModal} */}

--- a/client/src/components/Feed/PostCard.js
+++ b/client/src/components/Feed/PostCard.js
@@ -56,6 +56,7 @@ export default styled(Card)`
         font-weight: 400;
         font-size: ${medium};
         line-height: 2rem;
+        overflow-wrap: break-word;
       }
 
       .view-more {

--- a/client/src/components/Feed/PostCard.js
+++ b/client/src/components/Feed/PostCard.js
@@ -8,7 +8,7 @@ const { display } = typography.font.family;
 const { xsmall, medium, large, xxlarge } = typography.size;
 
 export default styled(Card)`
-  margin-bottom: 4rem;
+  margin-bottom: 2rem;
   border: unset !important;
   &.am-card,
   .am-card-body {

--- a/client/src/components/Feed/Posts.js
+++ b/client/src/components/Feed/Posts.js
@@ -5,7 +5,7 @@ export default ({ filteredPosts }) => {
   return (
     <div className="feed-posts">
       {filteredPosts.map((post) => (
-        <Post post={post} key={post._id} />
+        <Post post={post.fields} key={post.id} />
       ))}
     </div>
   );

--- a/client/src/components/Feed/Posts.js
+++ b/client/src/components/Feed/Posts.js
@@ -2,11 +2,15 @@ import React from "react";
 import Post from "./Post";
 
 export default ({ filteredPosts }) => {
-  return (
-    <div className="feed-posts">
-      {filteredPosts.map((post) => (
-        <Post post={post.fields} key={post.id} />
-      ))}
-    </div>
-  );
+  if (filteredPosts.length) {
+    return (
+      <div className="feed-posts">
+        {filteredPosts.map((post) => (
+          <Post post={post.fields} key={post.id} />
+        ))}
+      </div>
+    );
+  } else {
+    return <div>Loading posts...</div>;
+  }
 };

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -3,7 +3,6 @@ import axios from "axios";
 import { Link } from "react-router-dom";
 import ButtonModal from "../components/Feed/ButtonModal";
 import filterOptions from "../assets/data/filterOptions";
-import fakePosts from "../assets/data/fakePosts";
 import FeedWrapper from "../components/Feed/FeedWrapper";
 import FilterBox from "../components/Feed/FilterBox";
 import Posts from "../components/Feed/Posts";
@@ -48,6 +47,7 @@ export default () => {
     getCovidData();
   }, [getCovidData]);
 
+  // useReducer not redux
   const dispatchAction = (type, key, value) =>
     feedDispatch({ type, key, value });
 
@@ -66,7 +66,10 @@ export default () => {
     dispatchAction(TOGGLE_STATE, "filterModal");
     dispatchAction(SET_VALUE, "location", "");
     dispatchAction(SET_VALUE, "activePanel", null);
-    optionsDispatch({ type: REMOVE_ALL_OPTIONS, payload: {} });
+    optionsDispatch({
+      type: REMOVE_ALL_OPTIONS,
+      payload: {},
+    });
   };
 
   const handleLocation = (value) =>

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -1,4 +1,5 @@
-import React, { useReducer } from "react";
+import React, { useReducer, useEffect, useCallback } from "react";
+import axios from "axios";
 import { Link } from "react-router-dom";
 import ButtonModal from "../components/Feed/ButtonModal";
 import filterOptions from "../assets/data/filterOptions";
@@ -19,17 +20,33 @@ import {
 export const FeedContext = React.createContext();
 
 const initialState = {
+  covidData: [],
   filterModal: false,
   createPostModal: false,
   activePanel: null,
   location: "",
 };
+const airtableAPI =
+  "https://api.airtable.com/v0/appx4wP2PAcscbpFz/Projects%20and%20Initiatives?api_key=keyq3sfh3IOH4qf2g";
 
 export default () => {
   const [feedState, feedDispatch] = useReducer(feedReducer, initialState);
   const [selectedOptions, optionsDispatch] = useReducer(optionsReducer, {});
   const { filterModal, createPostModal, activePanel, location } = feedState;
   const filters = Object.values(filterOptions);
+
+  const getCovidData = useCallback(async () => {
+    try {
+      const res = await axios.get(airtableAPI);
+      dispatchAction(SET_VALUE, "covidData", res.data.records);
+    } catch (error) {
+      console.log(error);
+    }
+  }, []);
+
+  useEffect(() => {
+    getCovidData();
+  }, [getCovidData]);
 
   const dispatchAction = (type, key, value) =>
     feedDispatch({ type, key, value });

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -86,6 +86,9 @@ export default () => {
     dispatchAction(TOGGLE_STATE, "createPostModal");
   };
 
+  const filteredPosts = () =>
+    typeof feedState.covidData === "object" ? feedState.covidData : [];
+
   const renderCreatePostModal = () => {
     return (
       <ButtonModal
@@ -125,7 +128,7 @@ export default () => {
     >
       <FeedWrapper>
         <FilterBox />
-        <Posts filteredPosts={fakePosts} />
+        <Posts filteredPosts={filteredPosts()} />
         <CreatPostIcon onClick={handleCreatePost} className="create-post" />
         {renderCreatePostModal()}
       </FeedWrapper>


### PR DESCRIPTION
- Replaced dummy data from `fakePosts.js` with the fetched scraped data from Airtable to render them as posts in /feed
- Installed `react-read-more-read-less` to truncate post description
- Commented out code related to commenting and liking since the data coming from Airtable does contain data to support these functionalities

WIP
- Will need a way to add HTML to post descriptions:
    - You can see in the GIF that some descriptions don't have any line breaks (especially for the really long descriptions)
     - Turn url links in the descriptions into `<a href="" />` tags

*colors are blander than they actually are
![post](https://user-images.githubusercontent.com/42228386/79812978-41458c80-832f-11ea-86f4-c811b96c6db6.gif)

