### PR TITLE
Keep footnote at the bottom of the page

### DIFF
--- a/client/src/components/Footnote.js
+++ b/client/src/components/Footnote.js
@@ -7,10 +7,6 @@ import styled from "styled-components";
 const { colors } = theme;
 
 const StyledFooter = styled.footer`
-  position: absolute;
-  left: 0;
-  bottom: 0;
-
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -23,6 +19,7 @@ const StyledFooter = styled.footer`
   line-height: 2rem;
   font-family: Poppins;
   font-size: 1.1rem;
+  margin-top: 3rem;
 `;
 
 const Copyright = styled.div`


### PR DESCRIPTION
As pictured below, the footnote seems to be in a fixed position when scrolling a page. This PR attempts to fix this so that the footnote stays at the bottom, and should only be seen once reaching the bottom of the page. 

<img width="317" alt="Screen Shot 2020-04-24 at 2 10 32 PM" src="https://user-images.githubusercontent.com/42228386/80257416-b23dba80-8635-11ea-978c-b589da60bc03.png">
