### PR TITLE
Filter posts based on filters

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -107,7 +107,11 @@ async function routes(app) {
 
   app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
     const { helpType, needs } = req.query;
-    
+    const aggregates = [];
+
+    aggregates.push({ $unwind: "$needs" });
+
+    return Post.aggregate(aggregates);
   });
 
   app.delete(

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -28,7 +28,18 @@ async function routes(app) {
     // todo: add limit, skip, visibility filter, needs, tags ...
     const { authorId } = req.params;
     const { helpType, needs, fromWhom } = req.query;
-    const aggregates = authorId ? [{ $match: { authorId } }] : [];
+    const aggregates = authorId
+      ? [
+          {
+            $match: {
+              authorId,
+              helpType,
+              needs: { $in: needs },
+              fromWhom: { $in: fromWhom },
+            },
+          },
+        ]
+      : [];
     aggregates.push(
       {
         $lookup: {
@@ -52,15 +63,6 @@ async function routes(app) {
         },
       },
     );
-    // return Post.aggregate([
-    //   {
-    //     $match: {
-    //       helpType,
-    //       needs: { $in: needs },
-    //       fromWhom: { $in: fromWhom },
-    //     },
-    //   },
-    // ]);
     return Post.aggregate(aggregates);
   });
 

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -103,15 +103,9 @@ async function routes(app) {
 
   app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
     const { helpType, needs } = req.query;
-    const aggregates = [];
-
-    aggregates.push(
-      { $match: { helpType } },
-      { $match: { needs: { $in: needs } } },
-    );
     // todo: setup pagination to lazy load 10 posts
     // sort posts based on nearest location
-    return Post.aggregate(aggregates);
+    return Post.aggregate([{ $match: { helpType, needs: { $in: needs } } }]);
   });
 
   app.delete(

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -4,6 +4,7 @@ const mongoose = require("mongoose");
 const {
   getPostsSchema,
   getPostByIdSchema,
+  getPostByFiltersSchema,
   createPostSchema,
   deleteCommentSchema,
   deletePostSchema,
@@ -103,6 +104,11 @@ async function routes(app) {
       return post;
     },
   );
+
+  app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
+    const { helpType, needs } = req.query;
+    
+  });
 
   app.delete(
     "/:postId",

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -102,10 +102,18 @@ async function routes(app) {
   });
 
   app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
-    const { helpType, needs } = req.query;
+    const { helpType, needs, fromWhom } = req.query;
     // todo: setup pagination to lazy load 10 posts
     // sort posts based on nearest location
-    return Post.aggregate([{ $match: { helpType, needs: { $in: needs } } }]);
+    return Post.aggregate([
+      {
+        $match: {
+          helpType,
+          needs: { $in: needs },
+          fromWhom: { $in: fromWhom },
+        },
+      },
+    ]);
   });
 
   app.delete(

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -57,11 +57,10 @@ async function routes(app) {
 
   app.post(
     "/",
-    { schema: createPostSchema },
-    // { preValidation: [app.authenticate], schema: createPostSchema },
+    { preValidation: [app.authenticate], schema: createPostSchema },
     async (req) => {
       // todo add logged in user from jwt
-      // req.body.authorId = ""; // req.user.id;
+      req.body.authorId = ""; // req.user.id;
       return new Post(req.body).save();
     },
   );
@@ -110,7 +109,8 @@ async function routes(app) {
       { $match: { helpType } },
       { $match: { needs: { $in: needs } } },
     );
-
+    // todo: setup pagination to lazy load 10 posts
+    // sort posts based on nearest location
     return Post.aggregate(aggregates);
   });
 

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -57,10 +57,11 @@ async function routes(app) {
 
   app.post(
     "/",
-    { preValidation: [app.authenticate], schema: createPostSchema },
+    { schema: createPostSchema },
+    // { preValidation: [app.authenticate], schema: createPostSchema },
     async (req) => {
       // todo add logged in user from jwt
-      req.body.authorId = ""; // req.user.id;
+      // req.body.authorId = ""; // req.user.id;
       return new Post(req.body).save();
     },
   );

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -105,13 +105,13 @@ async function routes(app) {
   app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
     const { helpType, needs } = req.query;
     const aggregates = [];
-    const matchNeeds = needs.map((need) => {
-      needs: need;
-    });
-    aggregates.push({ $unwind: "$needs" }, { $match: { $or: matchNeeds } });
+
+    aggregates.push(
+      { $match: { helpType } },
+      { $match: { needs: { $in: needs } } },
+    );
 
     return Post.aggregate(aggregates);
-    // return Post.find({ helpType });
   });
 
   app.delete(

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -4,7 +4,6 @@ const mongoose = require("mongoose");
 const {
   getPostsSchema,
   getPostByIdSchema,
-  getPostByFiltersSchema,
   createPostSchema,
   deleteCommentSchema,
   deletePostSchema,
@@ -28,6 +27,7 @@ async function routes(app) {
   app.get("/", { schema: getPostsSchema }, async (req) => {
     // todo: add limit, skip, visibility filter, needs, tags ...
     const { authorId } = req.params;
+    const { helpType, needs, fromWhom } = req.query;
     const aggregates = authorId ? [{ $match: { authorId } }] : [];
     aggregates.push(
       {
@@ -52,6 +52,15 @@ async function routes(app) {
         },
       },
     );
+    // return Post.aggregate([
+    //   {
+    //     $match: {
+    //       helpType,
+    //       needs: { $in: needs },
+    //       fromWhom: { $in: fromWhom },
+    //     },
+    //   },
+    // ]);
     return Post.aggregate(aggregates);
   });
 
@@ -99,21 +108,6 @@ async function routes(app) {
     // todo: find a better way to return this from the comments aggregate
     post.commentsCount = await Comment.find({ postId }).count();
     return post;
-  });
-
-  app.get("/filters", { schema: getPostByFiltersSchema }, async (req) => {
-    const { helpType, needs, fromWhom } = req.query;
-    // todo: setup pagination to lazy load 10 posts
-    // sort posts based on nearest location
-    return Post.aggregate([
-      {
-        $match: {
-          helpType,
-          needs: { $in: needs },
-          fromWhom: { $in: fromWhom },
-        },
-      },
-    ]);
   });
 
   app.delete(

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -11,7 +11,7 @@ const createPostSchema = {
   body: S.object()
     .prop("title", S.string().required())
     .prop("description", S.string().required())
-    .prop("helpType", S.string())
+    .prop("helpType", S.string().required())
     .prop("needs", S.array().maxItems(10).items(S.string()).required()),
 };
 
@@ -25,15 +25,15 @@ const getPostByIdSchema = {
 const getPostByFiltersSchema = {
   querystring: S.object()
     .prop("helpType", S.string())
-    .prop("needs", S.array().maxItems(12).items(S.string()).required()),
+    .prop("needs", S.array().maxItems(12).items(S.string())),
 };
 
 const updatePostSchema = {
   body: S.object()
-    .prop("title", S.string().required())
-    .prop("description", S.string().required())
+    .prop("title", S.string())
+    .prop("description", S.string())
     .prop("helpType", S.string())
-    .prop("needs", S.array().maxItems(10).items(S.string()).required()),
+    .prop("needs", S.array().maxItems(10).items(S.string())),
   params: S.object().prop("postId", S.string().required()),
 };
 

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -4,7 +4,9 @@ const getPostsSchema = {
   querystring: S.object()
     .prop("authorId", S.string())
     .prop("skip", S.integer())
-    .prop("limit", S.integer()),
+    .prop("limit", S.integer())
+    .prop("helpType", S.string())
+    .prop("needs", S.array().maxItems(12).items(S.string())),
 };
 
 const createPostSchema = {
@@ -20,12 +22,6 @@ const getPostByIdSchema = {
     .prop("authorId", S.string())
     .prop("skip", S.integer())
     .prop("limit", S.integer()),
-};
-
-const getPostByFiltersSchema = {
-  querystring: S.object()
-    .prop("helpType", S.string())
-    .prop("needs", S.array().maxItems(12).items(S.string())),
 };
 
 const updatePostSchema = {

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -11,15 +11,8 @@ const createPostSchema = {
   body: S.object()
     .prop("title", S.string().required())
     .prop("description", S.string().required())
-    .prop("type", S.array().maxItems(10).items(S.string()).required())
-    .prop("shareWith", S.array().maxItems(10).items(S.string()))
-    .prop("needs", S.array().maxItems(10).items(S.string()).required())
-    .prop("tags", S.array().items(S.string()).required())
-    .prop("language", S.string().required())
-    .prop("website", S.string())
-    .prop("iosUrl", S.string())
-    .prop("androidUrl", S.string())
-    .prop("media", S.string()),
+    .prop("helpType", S.string())
+    .prop("needs", S.array().maxItems(10).items(S.string()).required()),
 };
 
 const getPostByIdSchema = {
@@ -31,17 +24,10 @@ const getPostByIdSchema = {
 
 const updatePostSchema = {
   body: S.object()
-    .prop("title", S.string())
-    .prop("description", S.string())
-    .prop("type", S.array().maxItems(10).items(S.string()))
-    .prop("shareWith", S.array().maxItems(10).items(S.string()))
-    .prop("needs", S.array().maxItems(10).items(S.string()))
-    .prop("tags", S.array().items(S.string()))
-    .prop("language", S.string())
-    .prop("website", S.string())
-    .prop("iosUrl", S.string())
-    .prop("androidUrl", S.string())
-    .prop("media", S.string()),
+    .prop("title", S.string().required())
+    .prop("description", S.string().required())
+    .prop("helpType", S.string())
+    .prop("needs", S.array().maxItems(10).items(S.string()).required()),
   params: S.object().prop("postId", S.string().required()),
 };
 

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -22,6 +22,12 @@ const getPostByIdSchema = {
     .prop("limit", S.integer()),
 };
 
+const getPostByFiltersSchema = {
+  querystring: S.object()
+    .prop("helpType", S.string())
+    .prop("needs", S.array().maxItems(12).items(S.string()).required()),
+};
+
 const updatePostSchema = {
   body: S.object()
     .prop("title", S.string().required())

--- a/backend/lib/models/schemas/Post.js
+++ b/backend/lib/models/schemas/Post.js
@@ -24,7 +24,10 @@ const PostSchema = new Schema(
       type: [String],
       // required: true,
     },
-    helpType: String,
+    helpType: {
+      type: String,
+      required: true,
+    },
     iosUrl: String,
     language: [String],
     likes: {
@@ -36,6 +39,7 @@ const PostSchema = new Schema(
     media: String,
     needs: {
       type: [String],
+      required: true,
     },
     postEmail: String,
     shareWith: {

--- a/backend/lib/models/schemas/Post.js
+++ b/backend/lib/models/schemas/Post.js
@@ -7,7 +7,7 @@ const PostSchema = new Schema(
     androidUrl: String,
     authorId: {
       ref: "users",
-      required: true,
+      // required: true,
       type: Schema.Types.ObjectId,
     },
     comments: {

--- a/backend/lib/models/schemas/Post.js
+++ b/backend/lib/models/schemas/Post.js
@@ -7,7 +7,7 @@ const PostSchema = new Schema(
     androidUrl: String,
     authorId: {
       ref: "users",
-      // required: true,
+      required: true,
       type: Schema.Types.ObjectId,
     },
     comments: {

--- a/backend/lib/models/schemas/Post.js
+++ b/backend/lib/models/schemas/Post.js
@@ -20,6 +20,11 @@ const PostSchema = new Schema(
       required: true,
       type: String,
     },
+    fromWhom: {
+      type: [String],
+      // required: true,
+    },
+    helpType: String,
     iosUrl: String,
     language: [String],
     likes: {
@@ -28,14 +33,9 @@ const PostSchema = new Schema(
     likesCount: {
       type: Number,
     },
-    looking: {
-      type: [String],
-      // required: true,
-    },
     media: String,
     needs: {
       type: [String],
-      // required: true,
     },
     postEmail: String,
     shareWith: {
@@ -46,14 +46,9 @@ const PostSchema = new Schema(
       type: Boolean,
       // required: true,
     },
-    tags: [String],
     title: {
       required: true,
       type: String,
-    },
-    type: {
-      type: [String],
-      // required: true,
     },
     website: String,
   },

--- a/client/src/assets/data/filterOptions.js
+++ b/client/src/assets/data/filterOptions.js
@@ -16,7 +16,7 @@ export default {
       "Others",
     ],
   },
-  type: {
+  needs: {
     label: "Type",
     className: "filter-3",
     options: [
@@ -34,7 +34,7 @@ export default {
       "Other",
     ],
   },
-  lookingFor: {
+  helpType: {
     label: "Need or give help",
     className: "filter-4",
     options: ["Need Help", "Give Help"],


### PR DESCRIPTION
- Started on a basic route `/api/posts/filters` that accepts filters as query params and queries into the db based on those filters

- Simplified some route schemas to not accept fields that are not absolutely needed (yet)

- Renamed the following fields in the Post model and route schema to match wording in `filterOptions.js`
  - `type` -> `needs`
  - `looking`/`lookingFor` -> `helpType`



Next Steps:
- I wonder if `GET api/posts/` should actually be handling filters instead of creating a new route like in this PR ? 

- I'll probably need to figure out a more efficient way of aggregating... would love any insights on the current implementation!

- Add backend pagination for the lazy loading feature of 10 posts, that are also sorted based on nearest location to the user

- Need to get clarification on the Post model. Right now when a user creates a post, the server gets data for `title`, `description`, `needs`, and `helpType`. Not sure when we get data from the user for the other fields like `fromWhom` and `tags`

Linked to issue #184 
 
