### PR TITLE
Remove ignore branch master from review delete workflow

### DIFF
--- a/.github/workflows/review-delete-workflow.yml
+++ b/.github/workflows/review-delete-workflow.yml
@@ -3,8 +3,6 @@ name: review-delete
 on:
   pull_request:
     types: [closed]
-    branches-ignore:
-      - 'master'
 
 jobs:
   destroy_review:


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [X] Have you checked out the guidelines in our [Contributing](../CONTRIBUTING.md) document?
* [X] Have you looked if there might be other open [Pull Requests](../../../pulls) for the same update/change?

### Quick Description of the PR

Fix the review-delete workflow. I believe that the `master` branch in `branches-ignore` is preventing this workflow from being run
