### PR TITLE
Feature/#210 fastify sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,19 @@ while developing. This is a living document, so feel free to add any notes that 
 
 ### Backend
 
-* Set `.additionalProperties(false)` for each schema defined with FluentSchema, to return a 400 bad request error if any
-additional properties not defined in the schema are passed in through the request.
-    * We are using [FluentSchema](https://github.com/fastify/fluent-schema) to validate backend requests. This is the
-    default validator for Fastify, our backend framework. FluentSchema uses ajv under the hood, and compiles to the
-    more standard JSON Schema.
+* API requests are validated using [Ajv](https://github.com/epoberezkin/ajv) and JSON schema's are defined with [FluentSchema](https://github.com/fastify/fluent-schema)
+    * By default, the schema's allow additional properties unless explicitly set that additional properties are not allowed.
+        There's a utility function `strictSchema()` in `lib/endpoints/schemas/utils.js` that can be used to initialize all schema's.
     * Rather than silently suppress additional properties, as is the default behavior for Fastify's ajv configuration,
-    we are instead returning a 400 bad request error if additional properties are passed in. This makes it easier to
-    debug issues due to a misspelled property name.
+        we are instead returning a 400 bad request error if additional properties are passed in. This makes it easier to
+        debug issues due to a misspelled property name.
+    * Read more about validation in Fastify in the docs https://www.fastify.io/docs/v2.2.x/Validation-and-Serialization/#validation
+* Endpoint handlers should use async functions, and return values or throw httpErrors.
+    * This is using some sensible defaults provided by https://github.com/fastify/fastify-sensible
+    * If an error is thrown, a generic error handler returns a 500 Internal Server Error response and logs the error details, 
+        without returning all error details in the response.
+    * Some more useful tools are provided by fastify-sensible such as built-in `fastify.httpErrors` and `fastify.to()` to [wrap async-await](https://github.com/scopsy/await-to-js)
+    * Read more in the Fastify documentation about using asyc/await with fastify https://www.fastify.io/docs/latest/Routes/#async-await
 
 ### Frontend
 * We have the beginnings of a theme. The file can be found here: `src/constants/theme.js` which has sections for typography, colors, buttons styles and media queries.

--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -1,5 +1,3 @@
-const httpErrors = require("http-errors");
-
 const Auth0 = require("../components/Auth0");
 const {
   loginSchema,
@@ -17,7 +15,7 @@ async function routes(app) {
     try {
       const { code, state } = req.body;
       if (decodeURIComponent(state) !== config.auth.state) {
-        return new httpErrors.Unauthorized("Invalid state");
+        throw app.httpErrors.unauthorized("Invalid state");
       }
       const token = await Auth0.authenticate("authorization_code", {
         code,
@@ -31,7 +29,7 @@ async function routes(app) {
       return { emailVerified, token };
     } catch (err) {
       req.log.error("OAuth error", err);
-      return new httpErrors.InternalServerError();
+      throw app.httpErrors.internalServerError();
     }
   });
 
@@ -65,10 +63,10 @@ async function routes(app) {
         req.log.info(`User created successfully email=${email}`);
       } catch (err) {
         if (err.statusCode === 409) {
-          return new httpErrors.Conflict("User already exists");
+          throw app.httpErrors.conflict("User already exists");
         }
         req.log.error("Error creating user", { err });
-        return new httpErrors.InternalServerError();
+        throw app.httpErrors.internalServerError();
       }
       const accessToken = await Auth0.authenticate("password", {
         password,
@@ -92,10 +90,10 @@ async function routes(app) {
       return { emailVerified, token };
     } catch (err) {
       if (err.statusCode === 403) {
-        return new httpErrors.Unauthorized("Wrong email or password.");
+        throw app.httpErrors.unauthorized("Wrong email or password.");
       }
       req.log.error("Error logging in", { err });
-      return new httpErrors.InternalServerError();
+      throw app.httpErrors.internalServerError();
     }
   });
 }

--- a/backend/lib/endpoints/users.js
+++ b/backend/lib/endpoints/users.js
@@ -1,5 +1,3 @@
-const httpErrors = require("http-errors");
-
 const { getUserByIdSchema } = require("./schema/users");
 
 /*
@@ -11,7 +9,7 @@ async function routes(app) {
   app.get("/current", { preValidation: [app.authenticate] }, async (req) => {
     const result = await User.findById(req.userId);
     if (result === null) {
-      return new httpErrors.NotFound();
+      throw app.httpErrors.notFound();
     }
     return {
       email: result.email,
@@ -27,7 +25,7 @@ async function routes(app) {
     async (req) => {
       const user = await User.findById(req.params.userId);
       if (user === null) {
-        return new httpErrors.NotFound();
+        throw app.httpErrors.notFound();
       }
       const { firstName, lastName, _id: id } = user;
       return {

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -1,3 +1,5 @@
+// todo: fix this by avoiding to import if possible
+// eslint-disable-next-line import/no-extraneous-dependencies
 const Ajv = require("ajv");
 const cors = require("cors");
 const fastify = require("fastify");
@@ -24,11 +26,12 @@ module.exports = function createApp(config) {
     return ajv.compile(schema);
   });
 
-  app.register(require("./plugins/mongoose-connector"), config.mongo);
-  app.register(require("./plugins/auth"), config.auth);
+  app.register(require("fastify-sensible"));
   app.register(require("fastify-oas"), {
     exposeRoute: true,
   });
+  app.register(require("./plugins/mongoose-connector"), config.mongo);
+  app.register(require("./plugins/auth"), config.auth);
   app.use(cors());
 
   app.get("/api/version", version);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1606,6 +1606,33 @@
         }
       }
     },
+    "fastify-sensible": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fastify-sensible/-/fastify-sensible-2.1.1.tgz",
+      "integrity": "sha512-wStXyzBWml2BZRqGMV0al8s6YGIa7GkSnxLCYQq/Xv1607rtGoja6gbzpf0HVhU1tAxLzvt65Eub7HutbNR8fA==",
+      "requires": {
+        "@types/node": "^12.0.7",
+        "fast-deep-equal": "^2.0.1",
+        "fastify-plugin": "^1.5.0",
+        "forwarded": "^0.1.2",
+        "http-errors": "^1.7.2",
+        "proxy-addr": "^2.0.5",
+        "type-is": "^1.6.18",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
+          "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "fastify-static": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-2.6.0.tgz",
@@ -3126,6 +3153,11 @@
         "pify": "^3.0.0"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -4608,6 +4640,15 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "fastify-jwt": "^1.3.1",
     "fastify-oas": "^2.6.2",
     "fastify-plugin": "^1.6.1",
+    "fastify-sensible": "^2.1.1",
     "fluent-schema": "^0.10.0",
     "http-errors": "^1.7.3",
     "mongoose": "^5.9.6",


### PR DESCRIPTION
### Quick Description of the PR
Closes #210 

### An Overview of the Changes
* Added fastify sensible plugin for more consistency and some default configurations
* Updated users and auth endpoints to use the included httpErrors (slightly different syntax than using the http-errors package directtly)
* Also updated the documentation about the backend

To do: added eslint ignore rule for the Ajv configuration because it's importing Ajv which isn't listed in package.json, but is a dependency of fastify. There is a better way to configure this but it's unclear based on different versions of the docs, so opened a new issue to fix this. #223 

Also to do: I didn't update all other handlers for posts because these are WIP in #191 for the data model update so when everything is updated the `http-errors` package can be removed