### PR TITLE
Create endpoint/backend for feedback form

### DIFF
--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -10,9 +10,9 @@ async function routes(app) {
     const { userId } = req.body;
 
     if (userId) {
-      const [err, userFeedback] = await app.to(Feedback.find({ userId }));
-      if (userFeedback[0] || err) {
-        throw app.httpErrors.internalServerError();
+      const [userFeedback] = await app.to(Feedback.findOne({ userId }));
+      if (userFeedback) {
+        throw app.httpErrors.conflict("Feedback already submitted");
       }
     }
 

--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -8,7 +8,7 @@ async function routes(app) {
 
   app.post("/", { schema: createFeedbackSchema }, async (req, reply) => {
     const { userId } = req.body;
-    let ip = "undefined";
+
     if (userId) {
       const userFeedback = await Feedback.find({ userId });
       if (userFeedback[0]) {
@@ -16,28 +16,14 @@ async function routes(app) {
       }
     }
 
-    if (req.ip !== null && typeof req.ip !== "undefined") {
-      ip = req.ip;
-      const feedbackFromIp = await Feedback.find({ ipAddress: ip });
-      if (feedbackFromIp[0]) {
-        reply.conflict("Feedback already submitted with this IP address");
-      }
-    }
-
-    if (userId || ip !== "undefined") {
-      return new Feedback({
-        ...req.body,
-        ipAddress: ip,
-      })
-        .save()
-        .then(() => {
-          reply.code(201).send({ success: true });
-        });
-    }
-
-    return reply.internalServerError(
-      "Authenticated user or ip required to save feedback",
-    );
+    return new Feedback({
+      ...req.body,
+      ipAddress: req.ip,
+    })
+      .save()
+      .then(() => {
+        reply.code(201).send({ success: true });
+      });
   });
 }
 

--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -1,0 +1,36 @@
+const httpErrors = require("http-errors");
+const { createFeedbackSchema } = require("./schema/feedback");
+
+/*
+ * /api/feedback
+ */
+async function routes(app) {
+  const Feedback = app.mongo.model("Feedback");
+
+  app.post("/", { schema: createFeedbackSchema }, async (req) => {
+    const { userId } = req.body;
+    let ip = "undefined";
+    if (userId) {
+      const userFeedback = await Feedback.find({ userId });
+      if (userFeedback[0]) {
+        return new httpErrors.Conflict("User already submitted feedback");
+      }
+    }
+
+    if (req.ip !== null && typeof req.ip !== "undefined") {
+      ip = req.ip;
+      const feedbackFromIp = await Feedback.find({ ipAddress: ip });
+      if (feedbackFromIp[0]) {
+        return new httpErrors.Conflict(
+          "Feedback already submitted with this IP address",
+        );
+      }
+    }
+    return new Feedback({
+      ...req.body,
+      ipAddress: ip,
+    }).save();
+  });
+}
+
+module.exports = routes;

--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -26,10 +26,16 @@ async function routes(app) {
         );
       }
     }
-    return new Feedback({
-      ...req.body,
-      ipAddress: ip,
-    }).save();
+
+    if (userId || ip !== "undefined") {
+      return new Feedback({
+        ...req.body,
+        ipAddress: ip,
+      }).save();
+    }
+    return new httpErrors.InternalServerError(
+      "Authenticated user or ip required to save feedback",
+    );
   });
 }
 

--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -23,13 +23,13 @@ async function routes(app) {
       }).save(),
     );
 
-    if (err) throw app.httpErrors.internalServerError();
+    if (err) {
+      req.log.error("Failed submitting feedback", { err });
+      throw app.httpErrors.internalServerError();
+    }
 
-    setImmediate(() => {
-      reply.code(201).send({ success: true });
-    });
-
-    return reply;
+    reply.code(201);
+    return { success: true };
   });
 }
 

--- a/backend/lib/endpoints/feedback.js
+++ b/backend/lib/endpoints/feedback.js
@@ -25,7 +25,11 @@ async function routes(app) {
 
     if (err) throw app.httpErrors.internalServerError();
 
-    return reply.code(201).send({ success: true });
+    setImmediate(() => {
+      reply.code(201).send({ success: true });
+    });
+
+    return reply;
   });
 }
 

--- a/backend/lib/endpoints/schema/feedback.js
+++ b/backend/lib/endpoints/schema/feedback.js
@@ -1,0 +1,17 @@
+const S = require("fluent-schema");
+const { strictSchema } = require("./utils");
+
+const createFeedbackSchema = {
+  body: strictSchema()
+    .prop("age", S.integer())
+    .prop("covidImpact", S.string())
+    .prop("generalFeedback", S.string())
+    .prop("mostValuableFeature", S.string())
+    .prop("rating", S.integer().required())
+    .prop("userId", S.string())
+    .prop("whatWouldChange", S.string()),
+};
+
+module.exports = {
+  createFeedbackSchema,
+};

--- a/backend/lib/endpoints/schema/feedback.js
+++ b/backend/lib/endpoints/schema/feedback.js
@@ -10,6 +10,10 @@ const createFeedbackSchema = {
     .prop("rating", S.integer().required())
     .prop("userId", S.string())
     .prop("whatWouldChange", S.string()),
+  connection: strictSchema().prop(
+    "remoteAddress",
+    S.string().format("ipv4").format("ipv6").required(),
+  ),
 };
 
 module.exports = {

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -5,12 +5,12 @@ const cors = require("cors");
 const fastify = require("fastify");
 
 const auth = require("./endpoints/auth");
+const feedback = require("./endpoints/feedback");
 const geo = require("./endpoints/geo");
 const organizations = require("./endpoints/organizations");
 const posts = require("./endpoints/posts");
 const users = require("./endpoints/users");
 const version = require("./endpoints/version");
-const feedback = require("./endpoints/feedback");
 
 module.exports = function createApp(config) {
   const app = fastify({
@@ -35,13 +35,13 @@ module.exports = function createApp(config) {
   app.register(require("./plugins/auth"), config.auth);
   app.use(cors());
 
-  app.get("/api/version", version);
   app.register(auth, { prefix: "/api/auth" });
+  app.register(feedback, { prefix: "/api/feedback" });
   app.register(geo, { prefix: "/api/geo" });
   app.register(organizations, { prefix: "api/organizations" });
   app.register(posts, { prefix: "/api/posts" });
   app.register(users, { prefix: "/api/users" });
-  app.register(feedback, { prefix: "/api/feedback" });
+  app.get("/api/version", version);
 
   return app;
 };

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -10,6 +10,7 @@ const organizations = require("./endpoints/organizations");
 const posts = require("./endpoints/posts");
 const users = require("./endpoints/users");
 const version = require("./endpoints/version");
+const feedback = require("./endpoints/feedback");
 
 module.exports = function createApp(config) {
   const app = fastify({
@@ -40,6 +41,7 @@ module.exports = function createApp(config) {
   app.register(organizations, { prefix: "api/organizations" });
   app.register(posts, { prefix: "/api/posts" });
   app.register(users, { prefix: "/api/users" });
+  app.register(feedback, { prefix: "/api/feedback" });
 
   return app;
 };

--- a/backend/lib/models/schemas/Feedback.js
+++ b/backend/lib/models/schemas/Feedback.js
@@ -1,0 +1,39 @@
+const { Schema } = require("mongoose");
+const { locationSchema } = require("./Location");
+
+// Feedback Schema
+const FeedbackSchema = new Schema(
+  {
+    age: {
+      get: (v) => Math.round(v),
+      set: (v) => Math.round(v),
+      type: Number,
+    },
+    covidImpact: String,
+    generalFeedback: String,
+    ipAddress: {
+      required: true,
+      type: String,
+    },
+    location: {
+      type: [locationSchema],
+    },
+    mostValuableFeature: String,
+    rating: {
+      get: (v) => Math.round(v),
+      max: 5,
+      min: 1,
+      required: true,
+      set: (v) => Math.round(v),
+      type: Number,
+    },
+    userId: {
+      ref: "User",
+      type: Schema.Types.ObjectId,
+    },
+    whatWouldChange: String,
+  },
+  { collection: "feedbacks", timestamps: true },
+);
+
+module.exports = FeedbackSchema;

--- a/backend/lib/models/schemas/Feedback.js
+++ b/backend/lib/models/schemas/Feedback.js
@@ -1,8 +1,7 @@
 const { Schema } = require("mongoose");
-const { locationSchema } = require("./Location");
 
 // Feedback Schema
-const FeedbackSchema = new Schema(
+const feedbackSchema = new Schema(
   {
     age: {
       get: (v) => Math.round(v),
@@ -15,9 +14,7 @@ const FeedbackSchema = new Schema(
       required: true,
       type: String,
     },
-    location: {
-      type: [locationSchema],
-    },
+    location: Object(),
     mostValuableFeature: String,
     rating: {
       get: (v) => Math.round(v),
@@ -28,7 +25,7 @@ const FeedbackSchema = new Schema(
       type: Number,
     },
     userId: {
-      ref: "User",
+      ref: "IndividualUser",
       type: Schema.Types.ObjectId,
     },
     whatWouldChange: String,
@@ -36,4 +33,4 @@ const FeedbackSchema = new Schema(
   { collection: "feedbacks", timestamps: true },
 );
 
-module.exports = FeedbackSchema;
+module.exports = feedbackSchema;

--- a/backend/lib/models/schemas/Feedback.js
+++ b/backend/lib/models/schemas/Feedback.js
@@ -25,7 +25,7 @@ const feedbackSchema = new Schema(
       type: Number,
     },
     userId: {
-      ref: "IndividualUser",
+      ref: "User",
       type: Schema.Types.ObjectId,
     },
     whatWouldChange: String,


### PR DESCRIPTION
Closes [148](https://github.com/FightPandemics/FightPandemics/issues/148)

- Adds feedback data model to mongo
- Adds fluent-schema for feedback data coming from the body of request
- Adds `api/feedback` endpoint to be used for form submission
  - Before saving it ensures that the each user and ip can only submit one feedback form. This was 
    discussed with @robinv85 as a desired check.
