### PR TITLE
Fixed path from Offerhelp issue #178

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15734,9 +15734,9 @@
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
     "react-hook-form": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.6.0.tgz",
-      "integrity": "sha512-/WGDFdrkooe71SKV1IB5bRRWmPHohQW2GfEYivc1mRGEuTIKIzNeAeSLZzTUzAXMVXcoCk2147mb15QwkoyIng=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.6.1.tgz",
+      "integrity": "sha512-pqlAiWyZqngdEVUinxPSmhs9k2L/ETsTf8LU7wfwrE1bXJnslRsb4aKlYiL2z0bgGrCuksN8el5bxFbnR1/qEA=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
-    "react-hook-form": "^5.6.0",
+    "react-hook-form": "^5.6.1",
     "react-load-script": "0.0.6",
     "react-moment": "^0.9.7",
     "react-redux": "^7.2.0",
@@ -27,10 +27,10 @@
     "react-step-wizard": "^5.3.2",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "snyk": "^1.316.2",
     "styled-components": "^5.0.1",
     "typeface-poppins": "^0.0.72",
-    "typeface-work-sans": "^0.0.72",
-    "snyk": "^1.316.2"
+    "typeface-work-sans": "^0.0.72"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -191,7 +191,7 @@ const OfferHelp = withRouter((props) => {
     if (key === "email") {
       localStorage.setItem("offerHelpAnswers", JSON.stringify(updatedAnswers));
       props.history.push({
-        pathname: "/medical",
+        pathname: "/Feed",
       });
     }
   };

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -191,7 +191,7 @@ const OfferHelp = withRouter((props) => {
     if (key === "email") {
       localStorage.setItem("offerHelpAnswers", JSON.stringify(updatedAnswers));
       props.history.push({
-        pathname: "/Feed",
+        pathname: "/feed",
       });
     }
   };


### PR DESCRIPTION
### Quick Description of the PR

Fixes issue #178 where the path from after submitting your email in offer help does not take you to the Feeds page like it should.

### An Overview of the Changes

* Changes the OfferHelp.js file.
* The path in line 194 was originally set to /medical but I changed it to /Feed so that the next page will be Feed.js.
