### PR TITLE
Add post review build URL to PR workflow

### DIFF
--- a/.github/workflows/review-build-url.yml
+++ b/.github/workflows/review-build-url.yml
@@ -1,0 +1,22 @@
+name: Post Review Build URL to PR
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  example:
+    name: Post to PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: get-branch-name-sanitized
+        name: Sanitize branch name
+        shell: bash
+        run: echo "::set-output name=branch::$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH" | tr -cd '[a-zA-Z0-9]_-')"
+      - name: Post Review Build URL
+        if: startsWith(steps.get-branch-name-sanitized.outputs.branch, 'feature')
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "Build URL: https://${{ steps.get-branch-name-sanitized.outputs.branch }}.fightpandemics.xyz. Please wait a few minutes for the deployment to complete."
+          check_for_duplicate_msg: true


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [X] Have you checked out the guidelines in our [Contributing](../CONTRIBUTING.md) document?
* [X] Have you looked if there might be other open [Pull Requests](../../../pulls) for the same update/change?

### Quick Description of the PR

Automatically post the review build URL to a PR when it is opened. Only runs on branches with the `feature/` prefix, since those are the only branches that are built and deployed to AWS review environment.

### An Overview of the Changes

* Added a new Github workflow to post a comment on the PR with the build URL when it is opened
