### PR TITLE
Terraform: use full MONGO_URI

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -34,7 +34,9 @@ const config = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     },
-    uri: `mongodb://${configData.MONGO_URI}`,
+    uri: configData.MONGO_URI.startsWith('mongodb://') || configData.MONGO_URI.startsWith('mongodb+srv://') ?
+      configData.MONGO_URI :
+      `mongodb://${configData.MONGO_URI}`,
   },
   name,
   server: {

--- a/main.tf
+++ b/main.tf
@@ -10,9 +10,17 @@ variable "auth_secret_key" {
 variable "auth_client_id" {
   type = string
 }
-variable "mongo_uri" {
-  type = string
-  default = "localhost:27017"
+
+data "aws_ssm_parameter" "db_host" {
+  name = "/fp/database/host"
+}
+
+data "aws_ssm_parameter" "db_user" {
+  name = "/fp/database/user"
+}
+
+data "aws_ssm_parameter" "db_password" {
+  name = "/fp/database/password"
 }
 
 module "main" {
@@ -27,7 +35,7 @@ module "main" {
     },
     {
       name  = "MONGO_URI"
-      value = var.mongo_uri
+      value = "${data.aws_ssm_parameter.db_user.value}:${data.aws_ssm_parameter.db_password.value}@${data.aws_ssm_parameter.db_host.value}:27017/fightpandemics"
     },
     {
       name  = "GEO_SERVICE_URL"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "main" {
     },
     {
       name  = "MONGO_URI"
-      value = "mongodb+srv://${data.aws_ssm_parameter.db_user.value}:${data.aws_ssm_parameter.db_password.value}@${data.aws_ssm_parameter.db_host.value}:27017/fightpandemics?retryWrites=true&w=majority"
+      value = "mongodb+srv://${data.aws_ssm_parameter.db_user.value}:${data.aws_ssm_parameter.db_password.value}@${data.aws_ssm_parameter.db_host.value}/fightpandemics?retryWrites=true&w=majority"
     },
     {
       name  = "GEO_SERVICE_URL"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "main" {
     },
     {
       name  = "MONGO_URI"
-      value = "${data.aws_ssm_parameter.db_user.value}:${data.aws_ssm_parameter.db_password.value}@${data.aws_ssm_parameter.db_host.value}:27017/fightpandemics"
+      value = "mongodb+srv://${data.aws_ssm_parameter.db_user.value}:${data.aws_ssm_parameter.db_password.value}@${data.aws_ssm_parameter.db_host.value}:27017/fightpandemics?retryWrites=true&w=majority"
     },
     {
       name  = "GEO_SERVICE_URL"


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [X] Have you checked out the guidelines in our [Contributing](../CONTRIBUTING.md) document?
* [X] Have you looked if there might be other open [Pull Requests](../../../pulls) for the same update/change?

### Quick Description of the PR

This allows the backend container to connect to our MongoDB Atlas cluster using the SSM parameters stored in AWS. These parameters were generated when configuring the cluster with the Terraform code in the infrastructure repo.

### An Overview of the Changes

* Get the AWS SSM parameters for the MongoDB host, user, and password, and build the `MONGO_URI` environment variable.
