### PR TITLE
fixed symptom done button button now redirects to feeds page as seen …

### DIFF
--- a/client/src/pages/ResultsPage.js
+++ b/client/src/pages/ResultsPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 import { AnswerButton } from "components/StepWizard";
 import GenericMessage from "./CovidScreening/GenericMessage";
@@ -15,7 +16,9 @@ const ResultsPage = (props) => {
           <p>{props.val[item]} </p>
         </div>
       ))}
-      <AnswerButton>Done</AnswerButton>
+      <Link to="/feed">
+        <AnswerButton>Done</AnswerButton>
+      </Link>
     </>
   );
 };


### PR DESCRIPTION
closes #306

An Overview of the Changes
As seen on the Figma screen clicking on the done button redirects the user to feeds page

Added a link on the button which now redirects users to the feeds page 

The button is now active and redirects to feed page as seen on the Figma screen