### PR TITLE
Connect client to backend through NGINX; expose Swagger API docs

### DIFF
--- a/backend/lib/endpoints/geo.js
+++ b/backend/lib/endpoints/geo.js
@@ -7,7 +7,7 @@ const { getCountrySchema } = require("./schema/geo");
 async function routes(app) {
   app.get(
     "/country",
-    { preValidation: [app.authenticate], schema: getCountrySchema },
+    { schema: getCountrySchema },
     async (req) => {
       const { latitude, longitude } = req.query;
       return findByLatLong(latitude, longitude);

--- a/backend/lib/index.js
+++ b/backend/lib/index.js
@@ -30,6 +30,7 @@ module.exports = function createApp(config) {
   app.register(require("fastify-sensible"));
   app.register(require("fastify-oas"), {
     exposeRoute: true,
+    routePrefix: "/api/documentation",
   });
   app.register(require("./plugins/mongoose-connector"), config.mongo);
   app.register(require("./plugins/auth"), config.auth);

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,3 +8,7 @@ RUN npm run build
 FROM nginx
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 3000 80
+
+ENTRYPOINT [ "nginx", "-g", "daemon off;" ]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,3 +7,4 @@ RUN npm run build
 
 FROM nginx
 COPY --from=builder /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx
+FROM nginx:alpine
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -18,7 +18,7 @@ http {
 
     location /api {
       # Reject requests with unsupported HTTP method
-      if ($request_method !~ ^(GET|POST|HEAD|OPTIONS|PUT|DELETE)$) {
+      if ($request_method !~ ^(GET|POST|HEAD|OPTIONS|PUT|PATCH|DELETE)$) {
         return 405;
       }
 

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -13,8 +13,9 @@ http {
 
   server {
     listen 80;
+    root /usr/share/nginx/html;
+    include /etc/nginx/mime.types;
 
-    # Nginx will reject anything not matching /api
     location /api {
       # Reject requests with unsupported HTTP method
       if ($request_method !~ ^(GET|POST|HEAD|OPTIONS|PUT|DELETE)$) {
@@ -23,7 +24,7 @@ http {
 
       # Only requests matching the whitelist expectations will
       # get sent to the application server
-      proxy_pass http://localhost:3000;
+      proxy_pass http://127.0.0.1:8000;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -32,4 +33,5 @@ http {
       proxy_cache_bypass $http_upgrade;
     }
   }
+
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -20,6 +20,10 @@ http {
       try_files $uri $uri/ /index.html;
       include /etc/nginx/mime.types;
     }
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+      root  /usr/share/nginx/html;
+    }
 
     location /api {
       # Reject requests with unsupported HTTP method
@@ -38,5 +42,4 @@ http {
       proxy_cache_bypass $http_upgrade;
     }
   }
-
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -13,8 +13,13 @@ http {
 
   server {
     listen 80;
-    root /usr/share/nginx/html;
-    include /etc/nginx/mime.types;
+
+    location / {
+      root /usr/share/nginx/html;
+      index index.html index.html;
+      try_files $uri $uri/ /index.html;
+      include /etc/nginx/mime.types;
+    }
 
     location /api {
       # Reject requests with unsupported HTTP method

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,35 @@
+# TODO move to separate sidecar container
+
+events {
+  worker_connections 768;
+}
+
+http {
+  # Nginx will handle gzip compression of responses from the app server
+  gzip on;
+  gzip_proxied any;
+  gzip_types text/plain application/json;
+  gzip_min_length 1000;
+
+  server {
+    listen 80;
+
+    # Nginx will reject anything not matching /api
+    location /api {
+      # Reject requests with unsupported HTTP method
+      if ($request_method !~ ^(GET|POST|HEAD|OPTIONS|PUT|DELETE)$) {
+        return 405;
+      }
+
+      # Only requests matching the whitelist expectations will
+      # get sent to the application server
+      proxy_pass http://localhost:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_cache_bypass $http_upgrade;
+    }
+  }
+}

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -16,7 +16,7 @@ http {
 
     location / {
       root /usr/share/nginx/html;
-      index index.html index.html;
+      index index.html;
       try_files $uri $uri/ /index.html;
       include /etc/nginx/mime.types;
     }

--- a/client/src/pages/Medical.js
+++ b/client/src/pages/Medical.js
@@ -67,9 +67,15 @@ const Medical = (props) => {
   };
 
   const fetchGeoData = () => {
-    const geolocation = getGeoLocation();
+    // Defaulting to San Francisco
+    // TODO fix geolocation
+    const defaultGeolocation = {
+      latitude: 37.733795,
+      longitude: -122.446747,
+    };
+    const geolocation = getGeoLocation() || defaultGeolocation;
     axios
-      .post("/api/geo/country", geolocation)
+      .get("/api/geo/country", { params: geolocation })
       .then((res) => {
         setState({ ...state, country: res.data });
         localStorage.setItem("country", JSON.stringify(res.data));


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [X] Have you checked out the guidelines in our [Contributing](https://github.com/FightPandemics/FightPandemics/blob/master/CONTRIBUTING.md) document?
* [X] Have you looked if there might be other open [Pull Requests](../../../pulls) for the same update/change?

### Quick Description of the PR

This hooks up the client container to the backend container in Fargate. I had to add an `nginx.conf` in the client container, and proxy requests to `/api` to the backend container.

I also exposed the Fastify Swagger docs at `/api/documentation`.

### An Overview of the Changes

* Add `nginx.conf` file
* Set Swagger doc route to `/api/documentation`
* Geolocation endpoint fixes - change to get, add default location if not set, remove authentication in the backend

Closes #337, #338, and #278 
