### PR TITLE
fix link on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:
 
 * [ ] Have you checked out the guidelines in our [Contributing](https://github.com/FightPandemics/FightPandemics/blob/master/CONTRIBUTING.md) document?
-* [ ] Have you looked if there might be other open [Pull Requests](../../../pulls) for the same update/change?
+* [ ] Have you looked if there might be other open [Pull Requests](https://github.com/FightPandemics/FightPandemics/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) for the same update/change?
 
 ### Quick Description of the PR
 


### PR DESCRIPTION

### Quick Description of the PR

when clicking on the pull requests link on the PR description when using a template

example

<img width="1602" alt="Screenshot 2020-05-12 at 04 27 14" src="https://user-images.githubusercontent.com/29093946/81635408-1bc91180-9409-11ea-9142-2cde341c7bdb.png">

would go to a link that filters the PR's opened by the user example 

https://github.com/pulls?q=is%3Apr+is%3Aopen+author%3Astavares843+archived%3Afalse+sort%3Aupdated-desc

instead of a link with the link of all the PR's example

https://github.com/FightPandemics/FightPandemics/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc