### PR TITLE
Fixed blue border #289

### DIFF
--- a/client/src/components/Button/FeedbackButton.js
+++ b/client/src/components/Button/FeedbackButton.js
@@ -12,6 +12,9 @@ const FeedbackButton = styled(Button)`
     background-color: #425af2;
     color: #fff;
   }
+  &.am-button-ghost:before {
+    border: none !important;
+  }
 `;
 
 export default FeedbackButton;


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [x] Have you checked out the guidelines in our [Contributing](https://github.com/FightPandemics/FightPandemics/blob/master/CONTRIBUTING.md) document?
* [x] Have you looked if there might be other open [Pull Requests](https://github.com/FightPandemics/FightPandemics/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) for the same update/change?

### Quick Description of the PR

Removes the 1px border that was shown in the original issue ticket.

### An Overview of the Changes

* The issue stems from inbuilt styles in the antd-mobile (Ant Designs) Button Component. In particular the following media query exists and I suppose need to be manually overridden in the component using the antd-mobile (Ant Designs) Button Component.

```
@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
  ...
  html:not([data-scale]) .am-button-ghost::before {
    ...
    border: 1PX solid #108ee9;
    ...
}
```

* The following was added to the client/src/components/Button/FeedbackButton.js file to suppress the border shown above:

```
  &.am-button-ghost:before {
    border: none !important;
  }
```

* Is there a better way?