### PR TITLE
#279 fix icon layout

### DIFF
--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -70,15 +70,6 @@ const StyledComment = styled(Comment)`
                   margin-right: 12px;
                 }
 
-                input {
-                  background-color: ${lighterGray};
-                  color: black;
-                  border-bottom: unset;
-                  border-radius: 4rem;
-                  padding: 1.4rem;
-                  width: 100%;
-                }
-
                 textarea {
                   width: calc(100% - 50px);
                 }

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -69,6 +69,7 @@ const StyledComment = styled(Comment)`
                   padding-right: 0;
                   margin-right: 12px;
                 }
+
                 input {
                   background-color: ${lighterGray};
                   color: black;
@@ -76,6 +77,10 @@ const StyledComment = styled(Comment)`
                   border-radius: 4rem;
                   padding: 1.4rem;
                   width: 100%;
+                }
+
+                textarea {
+                  width: calc(100% - 50px);
                 }
               }
             }


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [x] Have you checked out the guidelines in our [Contributing](https://github.com/FightPandemics/FightPandemics/blob/master/CONTRIBUTING.md) document?
* [x] Have you looked if there might be other open [Pull Requests](https://github.com/FightPandemics/FightPandemics/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) for the same update/change?

### Quick Description of the PR

Avatar icon is squished below its size of 32x32 by sibling textarea node and as a result, a bit of the image is cut off. I've added a CSS rule to calculate the textarea width based on the avatar horizontal size + offset.

Also removed unused css.

### An Overview of the Changes

* A few notes on your commits.
* To help understand them.

**Issue:**

![screen shot](https://user-images.githubusercontent.com/29093946/81510500-f99c9a00-9309-11ea-818d-2c5ebe7c3e1d.png)

**Fixed:**

![Screen Shot 2020-05-15 at 6 03 22 PM](https://user-images.githubusercontent.com/26049767/82106548-a1cdac80-96d6-11ea-8b10-f848f424c282.png)

iPhone X:
![Screen Shot 2020-05-15 at 6 02 00 PM](https://user-images.githubusercontent.com/26049767/82106553-ad20d800-96d6-11ea-9e21-b367edd09bf2.png)

### Area of concern:
There's an issue with the current way of nesting comments and replies. At a certain point, the comments are offset so far to the right that there's no horizontal space left. **I've confirmed that this is a pre-existing issue prior to my changes.**

Problem on PR branch:
![Screen Shot 2020-05-15 at 8 13 32 PM](https://user-images.githubusercontent.com/26049767/82109442-b451e100-96ea-11ea-9b6e-aac27212a396.png)

Problem on Master branch:
![Screen Shot 2020-05-15 at 8 16 39 PM](https://user-images.githubusercontent.com/26049767/82109446-c7fd4780-96ea-11ea-908b-227b5ac59af7.png)

I will submit a bug for this issue.