### PR TITLE
Add automatic index syncing between model and db

### DIFF
--- a/backend/lib/plugins/mongoose-connector.js
+++ b/backend/lib/plugins/mongoose-connector.js
@@ -9,10 +9,19 @@ require("../models/Organization");
 require("../models/Post");
 require("../models/User");
 
+async function syncIndexes(mongo) {
+  mongo.model("Comment").syncIndexes();
+  mongo.model("Feedback").syncIndexes();
+  mongo.model("Location").syncIndexes();
+  mongo.model("Organization").syncIndexes();
+  mongo.model("Post").syncIndexes();
+  mongo.model("User").syncIndexes();
+}
+
 async function dbConnector(app, config) {
   const connection = await mongoose.createConnection(config.uri, config.params);
-
-  app.decorate("mongo", connection);
+  app.decorate("mongo", connection);  
+  syncIndexes(app.mongo);
 }
 
 module.exports = fp(dbConnector);


### PR DESCRIPTION
### PR Checklist:

Hey there! It's great to have you here. Here's a quick checklist to help you make a shiny PR:

* [X] Have you checked out the guidelines in our [Contributing](https://github.com/FightPandemics/FightPandemics/blob/master/CONTRIBUTING.md) document?
* [X] Have you looked if there might be other open [Pull Requests](https://github.com/FightPandemics/FightPandemics/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) for the same update/change?

### Quick Description of the PR

Add syncing between the indexes defined at model and the ones present at the database.

This way, it will ensure that index created at the database and defined at model schema are always in sync.
If a new index is added at the schema it will create at the database.
If an index is removed from the model, it will remove it from the database too.

Closes #375 

### An Overview of the Changes

* Add calls to `syncIndexes()` for each model at `mongoose-connector`
http://thecodebarbarian.com/whats-new-in-mongoose-5-2-syncindexes
