### PR TITLE
Separate Auth0 tenants for each environment

### DIFF
--- a/.github/workflows/review-delete-workflow.yml
+++ b/.github/workflows/review-delete-workflow.yml
@@ -14,8 +14,6 @@ jobs:
         shell: bash
         run: echo "::set-output name=branch::$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH" | tr -cd '[a-zA-Z0-9]_-')"
       - env:
-          AUTH_SECRET_KEY: ${{ secrets.AUTH_SECRET_KEY }}
-          AUTH_CLIENT_ID: ${{ secrets.AUTH_CLIENT_ID }}
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
@@ -51,5 +49,4 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           TF_VAR_env_name: ${{ steps.get-branch-name-sanitized.outputs.branch }}
           TF_VAR_fp_context: review
-          TF_VAR_auth_secret_key: ${{ secrets.AUTH_SECRET_KEY }}
-          TF_VAR_auth_client_id: ${{ secrets.AUTH_CLIENT_ID }}
+

--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -57,8 +57,6 @@ jobs:
         shell: bash
         run: echo "::set-output name=branch::$(echo ${{ steps.get-branch-name.outputs.branch }} | tr -cd '[a-zA-Z0-9]_-')"
       - env:
-          AUTH_SECRET_KEY: ${{ secrets.AUTH_SECRET_KEY }}
-          AUTH_CLIENT_ID: ${{ secrets.AUTH_CLIENT_ID }}
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
@@ -94,8 +92,6 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           TF_VAR_env_name: ${{ steps.get-branch-name-sanitized.outputs.branch }}
           TF_VAR_fp_context: review
-          TF_VAR_auth_secret_key: ${{ secrets.AUTH_SECRET_KEY }}
-          TF_VAR_auth_client_id: ${{ secrets.AUTH_CLIENT_ID }}
       - uses: ItsKarma/aws-cli@v1.70.0
         with:
           args: ecs update-service --cluster review-cluster --service ${{ steps.get-branch-name-sanitized.outputs.branch }} --force-new-deployment

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -45,8 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - env:
-          AUTH_SECRET_KEY: ${{ secrets.AUTH_SECRET_KEY }}
-          AUTH_CLIENT_ID: ${{ secrets.AUTH_CLIENT_ID }}
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
@@ -82,8 +80,6 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           TF_VAR_env_name: staging
           TF_VAR_fp_context: staging
-          TF_VAR_auth_secret_key: ${{ secrets.AUTH_SECRET_KEY }}
-          TF_VAR_auth_client_id: ${{ secrets.AUTH_CLIENT_ID }}
       - uses: ItsKarma/aws-cli@v1.70.0
         with:
           args: ecs update-service --cluster staging-cluster --service staging --force-new-deployment

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 variable "env_name" {
   type = string
 }
+
 variable "fp_context" {
   type = string
 }

--- a/main.tf
+++ b/main.tf
@@ -4,12 +4,6 @@ variable "env_name" {
 variable "fp_context" {
   type = string
 }
-variable "auth_secret_key" {
-  type = string
-}
-variable "auth_client_id" {
-  type = string
-}
 
 data "aws_ssm_parameter" "db_host" {
   name = "/fp/database/host"
@@ -21,6 +15,18 @@ data "aws_ssm_parameter" "db_user" {
 
 data "aws_ssm_parameter" "db_password" {
   name = "/fp/database/password"
+}
+
+data "aws_ssm_parameter" "auth_domain" {
+  name = "/fp/auth/domain"
+}
+
+data "aws_ssm_parameter" "auth_client_id" {
+  name = "/fp/auth/client_id"
+}
+
+data "aws_ssm_parameter" "auth_client_secret" {
+  name = "/fp/auth/client_secret"
 }
 
 module "main" {
@@ -51,15 +57,15 @@ module "main" {
     },
     {
       name  = "AUTH_SECRET_KEY"
-      value = var.auth_secret_key
+      value = data.aws_ssm_parameter.auth_client_secret.value
     },
     {
       name  = "AUTH_DOMAIN"
-      value = "fightpandemics.eu.auth0.com"
+      value = data.aws_ssm_parameter.auth_domain.value
     },
     {
       name  = "AUTH_CLIENT_ID"
-      value = var.auth_client_id
+      value = data.aws_ssm_parameter.auth_client_id.value
     },
     {
       name  = "NODE_ENV"


### PR DESCRIPTION
### What does this pull request aim to achieve?

This enables fetching of Auth0 secrets based on the environment being deployed. I have set up three new tenants in Auth0: staging, review, and production.

Instead of storing the Auth0 secrets in the GitHub repo secrets, I have moved them to AWS SSM Parameter store, which is more secure, and easier to separate by environment (each environment has its own AWS account)

Resolves #350 

### Before submitting this pull request:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`**.
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
