### PR TITLE
feat: add descriptive error for weak password on signup through Auth0…

### DIFF
--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -69,6 +69,10 @@ async function routes(app) {
       } catch (err) {
         if (err.statusCode === 409) {
           throw app.httpErrors.conflict("User already exists");
+        } else if (
+          err.message === "PasswordStrengthError: Password is too weak"
+        ) {
+          throw app.httpErrors.badRequest("Password is too weak");
         }
         req.log.error("Error creating user", { err });
         throw app.httpErrors.internalServerError();


### PR DESCRIPTION
# What does this pull request aim to achieve?
Fixes #225 
add descriptive error for weak password on signup through Auth0 createUser
This is one very specific error handled on the backend right now, instead of just returning everything from Auth0 directly

I will open a new ticket to improve UX, we can probably add client-side validation and API validation with a regex for this password complexity so the user gets more info. Also, maybe we should show this info when the user signs up so at least they know what's required.

By the way from the PR template: 
6. There are no console warnings and errors.
=> just saying but these are on master right now :) 