### PR TITLE
Feature/[406]Changed default text from in my zip code to in my city

### DIFF
--- a/client/src/assets/data/createPostSettings.js
+++ b/client/src/assets/data/createPostSettings.js
@@ -2,9 +2,9 @@ export default {
   shareWith: {
     type: "shareWith",
     title: "Share with ...",
-    default: { text: "In my Zip Code", value: "Zip Code" },
+    default: { text: "In my City", value: "City" },
     options: [
-      { text: "In my Zip Code", value: "Zip Code" },
+      { text: "In my City", value: "City" },
       { text: "In my State", value: "State" },
       { text: "In my Country", value: "Country" },
       { text: "Worldwide", value: "Worldwide" },


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Expected State:
replaced "In my City"/"City" in createPostSettings.js instead of "In my Zip Code"/"Zip Code"

