### PR TITLE
trim Posts.externalLinks items

### DIFF
--- a/backend/lib/models/Post.js
+++ b/backend/lib/models/Post.js
@@ -12,10 +12,10 @@ const postSchema = new Schema(
     },
     expireAt: Date,
     externalLinks: {
-      appStore: String,
-      email: String,
-      playStore: String,
-      website: String,
+      appStore: { trim: true, type: String },
+      email: { trim: true, type: String },
+      playStore: { trim: true, type: String },
+      website: { trim: true, type: String },
     },
     language: [String],
     likes: {


### PR DESCRIPTION
Resolves #413 

As per discussion: https://github.com/FightPandemics/FightPandemics/pull/408#discussion_r427715558

The fluent schema (url/email) would prevent a value with leading/trailing whitespace but for consistency & non-API data loading I've added `trim: true` to the schema.