### PR TITLE
Feature/auth errors frontend

### DIFF
--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -1,8 +1,4 @@
-import axios from "axios";
-import { Toast } from "antd-mobile";
-
-import { GET_ERRORS } from "./types";
-import { AUTH_LOGIN, AUTH_SIGNUP } from "constants/action-types";
+import { AUTH_SUCCESS } from "constants/action-types";
 import { getAuthToken } from "utils/auth-token";
 
 // Note: for production apps, both localstorage & cookies contain risks to store user & auth data
@@ -10,55 +6,7 @@ export const initAuth = () => {
   return (dispatch) => {
     const token = getAuthToken();
     if (token) {
-      dispatch({ type: AUTH_LOGIN, payload: { token } });
-    }
-  };
-};
-
-export const submitEmail = (userData, history) => (dispatch) => {
-  axios
-    .post("/api/users/login", userData)
-    .then((res) => history.push("/medicals"))
-    .catch((err) =>
-      dispatch({
-        type: GET_ERRORS,
-        payload: err.response.data,
-      }),
-    );
-};
-
-export const loginWithEmail = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post("/api/auth/login", payload);
-      dispatch({ type: AUTH_LOGIN, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      Toast.fail(`Login failed, reason: ${message}`, 3);
-    }
-  };
-};
-
-export const authWithSocialProvider = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post(`/api/auth/oauth`, payload);
-      dispatch({ type: AUTH_LOGIN, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      Toast.fail(`Login failed, reason: ${message}`, 3);
-    }
-  };
-};
-
-export const signup = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post("/api/auth/signup", payload);
-      dispatch({ type: AUTH_SIGNUP, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      Toast.fail(`Signup failed, reason: ${message}`, 3);
+      dispatch({ type: AUTH_SUCCESS, payload: { token } });
     }
   };
 };

--- a/client/src/constants/action-types.js
+++ b/client/src/constants/action-types.js
@@ -1,4 +1,2 @@
-export const AUTH_LOGIN = "AUTH_LOGIN";
+export const AUTH_SUCCESS = "AUTH_LOGIN";
 export const AUTH_LOGOUT = "AUTH_LOGOUT";
-export const AUTH_SIGNUP = "AUTH_LOGIN";
-export const SET_USER = "SET_USER";

--- a/client/src/hooks/actions/authFormActions.js
+++ b/client/src/hooks/actions/authFormActions.js
@@ -1,0 +1,43 @@
+export const AUTH_FORM_LOGIN = "AUTH_FORM_LOGIN";
+export const AUTH_FORM_LOGIN_ERROR = "AUTH_FORM_LOGIN_ERROR";
+
+export const AUTH_FORM_SIGNUP = "AUTH_FORM_SIGNUP";
+export const AUTH_FORM_SIGNUP_ERROR = "AUTH_FORM_SIGNUP_ERROR";
+
+/*
+export const loginWithEmail = (payload) => {
+  return async (dispatch) => {
+    try {
+      const res = await axios.post("/api/auth/login", payload);
+      dispatch({ type: AUTH_LOGIN, payload: res.data });
+    } catch (err) {
+      const message = err.response?.data?.message || err.message;
+      // Toast.fail(`Login failed, reason: ${message}`, 3);
+    }
+  };
+};
+
+export const authWithSocialProvider = (payload) => {
+  return async (dispatch) => {
+    try {
+      const res = await axios.post(`/api/auth/oauth`, payload);
+      dispatch({ type: AUTH_LOGIN, payload: res.data });
+    } catch (err) {
+      const message = err.response?.data?.message || err.message;
+      // Toast.fail(`Login failed, reason: ${message}`, 3);
+    }
+  };
+};
+
+export const signup = (payload) => {
+  return async (dispatch) => {
+    try {
+      const res = await axios.post("/api/auth/signup", payload);
+      dispatch({ type: AUTH_SIGNUP, payload: res.data });
+    } catch (err) {
+      const message = err.response?.data?.message || err.message;
+      // Toast.fail(`Signup failed, reason: ${message}`, 3);
+    }
+  };
+};
+*/

--- a/client/src/hooks/actions/authFormActions.js
+++ b/client/src/hooks/actions/authFormActions.js
@@ -4,40 +4,5 @@ export const AUTH_FORM_LOGIN_ERROR = "AUTH_FORM_LOGIN_ERROR";
 export const AUTH_FORM_SIGNUP = "AUTH_FORM_SIGNUP";
 export const AUTH_FORM_SIGNUP_ERROR = "AUTH_FORM_SIGNUP_ERROR";
 
-/*
-export const loginWithEmail = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post("/api/auth/login", payload);
-      dispatch({ type: AUTH_LOGIN, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      // Toast.fail(`Login failed, reason: ${message}`, 3);
-    }
-  };
-};
-
-export const authWithSocialProvider = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post(`/api/auth/oauth`, payload);
-      dispatch({ type: AUTH_LOGIN, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      // Toast.fail(`Login failed, reason: ${message}`, 3);
-    }
-  };
-};
-
-export const signup = (payload) => {
-  return async (dispatch) => {
-    try {
-      const res = await axios.post("/api/auth/signup", payload);
-      dispatch({ type: AUTH_SIGNUP, payload: res.data });
-    } catch (err) {
-      const message = err.response?.data?.message || err.message;
-      // Toast.fail(`Signup failed, reason: ${message}`, 3);
-    }
-  };
-};
-*/
+export const AUTH_FORM_SOCIAL = "AUTH_FORM_SOCIAL";
+export const AUTH_FORM_SOCIAL_ERROR = "AUTH_FORM_SOCIAL_ERROR";

--- a/client/src/hooks/reducers/authFormReducer.js
+++ b/client/src/hooks/reducers/authFormReducer.js
@@ -3,6 +3,8 @@ import {
   AUTH_FORM_LOGIN_ERROR,
   AUTH_FORM_SIGNUP,
   AUTH_FORM_SIGNUP_ERROR,
+  AUTH_FORM_SOCIAL,
+  AUTH_FORM_SOCIAL_ERROR,
 } from "../actions/authFormActions";
 
 export const initialState = {
@@ -15,9 +17,11 @@ export const authFormReducer = (state, action) => {
   switch (type) {
     case AUTH_FORM_LOGIN:
     case AUTH_FORM_SIGNUP:
+    case AUTH_FORM_SOCIAL:
       return { ...state, loading: true, error: null };
     case AUTH_FORM_LOGIN_ERROR:
     case AUTH_FORM_SIGNUP_ERROR:
+    case AUTH_FORM_SOCIAL_ERROR:
       return { ...state, loading: false, error: payload.error };
     default:
       return state;

--- a/client/src/hooks/reducers/authFormReducer.js
+++ b/client/src/hooks/reducers/authFormReducer.js
@@ -1,0 +1,25 @@
+import {
+  AUTH_FORM_LOGIN,
+  AUTH_FORM_LOGIN_ERROR,
+  AUTH_FORM_SIGNUP,
+  AUTH_FORM_SIGNUP_ERROR,
+} from "../actions/authFormActions";
+
+export const initialState = {
+  error: null,
+  loading: false,
+};
+
+export const authFormReducer = (state, action) => {
+  const { type, ...payload } = action;
+  switch (type) {
+    case AUTH_FORM_LOGIN:
+    case AUTH_FORM_SIGNUP:
+      return { ...state, loading: true, error: null };
+    case AUTH_FORM_LOGIN_ERROR:
+    case AUTH_FORM_SIGNUP_ERROR:
+      return { ...state, loading: false, error: payload.error };
+    default:
+      return state;
+  }
+};

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -4,30 +4,27 @@ import axios from "axios";
 import React, { useEffect, useReducer, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 
-import {
-  AUTH_SUCCESS,
-} from "constants/action-types";
+import { AUTH_SUCCESS } from "constants/action-types";
 import { PASSWORD_MIN_LENGTH } from "config";
 import {
   AUTH_FORM_LOGIN,
   AUTH_FORM_LOGIN_ERROR,
   AUTH_FORM_SIGNUP,
   AUTH_FORM_SIGNUP_ERROR,
+  AUTH_FORM_SOCIAL,
+  AUTH_FORM_SOCIAL_ERROR,
 } from "hooks/actions/authFormActions";
-import {
-  authFormReducer,
-  initialState,
-} from "hooks/reducers/authFormReducer";
-
+import { authFormReducer, initialState } from "hooks/reducers/authFormReducer";
 import SubmitButton from "components/Button/SubmitButton";
 import Label from "components/Input/Label";
 import Input from "components/Input/BaseInput";
 // import { validateEmail } from "utils/common.js";
-// import { useQuery } from "utils/hooks.js";
+import { useQuery } from "utils/hooks.js";
 import Heading from "components/Typography/Heading";
-
+import { ORANGE_RED, WHITE } from "constants/colors";
 import { theme, mq } from "constants/theme";
 
 // ICONS
@@ -107,13 +104,11 @@ const ButtonText = styled.span`
   color: ${colors.darkGray};
 `;
 
-const AuthLink = styled.a`
+const AuthLink = styled(Link)`
   font-family: ${typography.font.family.display};
-  font-style: normal;
   font-weight: 300;
   font-size: 1.6rem;
   line-height: 2.1rem;
-  text-align: center;
   color: ${colors.royalBlue};
 `;
 
@@ -142,6 +137,13 @@ const LoginLeftContainer = styled.div`
 
 const LoginRightContainer = styled.div`
   flex: 1;
+`;
+
+const ErrorAlert = styled(Alert)`
+  background-color: ${ORANGE_RED};
+  .ant-alert-message {
+    color: ${WHITE};
+  }
 `;
 
 const SocialImageContainer = styled.div`
@@ -188,21 +190,38 @@ const VisibilityButton = ({ onClick, type }) => {
 
 const Login = ({ isLoginForm }) => {
   const dispatch = useDispatch();
-  const { formState, getValues, handleSubmit, register } = useForm();
-  const [authFormState, authFormDispatch] = useReducer(authFormReducer, initialState);
+  const { formState, getValues, handleSubmit, register } = useForm({
+    mode: "change",
+  });
+  const [authFormState, authFormDispatch] = useReducer(
+    authFormReducer,
+    initialState,
+  );
   const [passwordType, setPasswordType] = useState("password");
   const [confirmPasswordType, setConfirmPasswordType] = useState("password");
-  /*
-    const queryParams = useQuery();
-    const code = queryParams.get("code");
-    const state = queryParams.get("state");
+  const queryParams = useQuery();
+  const code = queryParams.get("code");
+  const state = queryParams.get("state");
 
-    useEffect(() => {
-      if (code && state) {
-        dispatch(authWithSocialProvider({ code, state }));
-      }
-    }, [code, state, dispatch]);
-  */
+  useEffect(() => {
+    if (code && state) {
+      const loadOAuth = async () => {
+        authFormDispatch({ type: AUTH_FORM_SOCIAL });
+        try {
+          const res = await axios.post(`/api/auth/oauth`, { code, state });
+          dispatch({ type: AUTH_SUCCESS, payload: res.data });
+        } catch (err) {
+          const message = err.response?.data?.message || err.message;
+          authFormDispatch({
+            type: AUTH_FORM_SOCIAL_ERROR,
+            error: `Authentication failed, reason: ${message}`,
+          });
+        }
+      };
+      loadOAuth();
+    }
+  }, [code, state, dispatch]);
+
   const onLoginWithEmail = async (formData) => {
     authFormDispatch({ type: AUTH_FORM_LOGIN });
     try {
@@ -210,7 +229,11 @@ const Login = ({ isLoginForm }) => {
       dispatch({ type: AUTH_SUCCESS, payload: res.data });
     } catch (err) {
       const message = err.response?.data?.message || err.message;
-      authFormDispatch({ type: AUTH_FORM_LOGIN_ERROR, error: `Login failed, reason: ${message}` });
+      authFormDispatch({
+        type: AUTH_FORM_LOGIN_ERROR,
+        error: `Login failed, reason: ${message}`,
+      });
+    }
   };
 
   const onSignup = async (formData) => {
@@ -220,7 +243,10 @@ const Login = ({ isLoginForm }) => {
       dispatch({ type: AUTH_SUCCESS, payload: res.data });
     } catch (err) {
       const message = err.response?.data?.message || err.message;
-      authFormDispatch({ type: AUTH_FORM_SIGNUP_ERROR, error: `Signup failed, reason: ${message}` });
+      authFormDispatch({
+        type: AUTH_FORM_SIGNUP_ERROR,
+        error: `Signup failed, reason: ${message}`,
+      });
     }
   };
 
@@ -266,9 +292,9 @@ const Login = ({ isLoginForm }) => {
             <Heading className="h4" level={4}>
               {isLoginForm ? "Sign In" : "Sign Up"}
             </Heading>
-            {authFormState.error &&
-              <Alert message={authFormState.error} type="error" />
-            }
+            {authFormState.error && (
+              <ErrorAlert message={authFormState.error} type="error" />
+            )}
             <form id="login-password">
               <InputWrapper>
                 <Label for="email" style={StyleLabel} label="E-mail" />
@@ -308,14 +334,12 @@ const Login = ({ isLoginForm }) => {
                     name="confirmPassword"
                     required
                     placeholder="Confirm password"
-                    ref={
-                      register({
-                        minLength: PASSWORD_MIN_LENGTH,
-                        validate: {
-                          matchesPreviousPassword: comparePasswordConfirmation,
-                        }
-                      })
-                    }
+                    ref={register({
+                      minLength: PASSWORD_MIN_LENGTH,
+                      validate: {
+                        matchesPreviousPassword: comparePasswordConfirmation,
+                      },
+                    })}
                     style={StyleInput}
                   />
                   <VisibilityButton
@@ -327,7 +351,11 @@ const Login = ({ isLoginForm }) => {
               <SubmitButton
                 primary="true"
                 disabled={!formState.isValid}
-                onClick={isLoginForm ? handleSubmit(onLoginWithEmail) : handleSubmit(onSignup)}
+                onClick={
+                  isLoginForm
+                    ? handleSubmit(onLoginWithEmail)
+                    : handleSubmit(onSignup)
+                }
               >
                 {isLoginForm ? "Sign In" : "Sign Up"}
               </SubmitButton>
@@ -337,19 +365,19 @@ const Login = ({ isLoginForm }) => {
             {isLoginForm ? (
               <>
                 <p>
-                  <AuthLink href="/auth/forgot-password">
+                  <AuthLink to="/auth/forgot-password">
                     Forgot password?
                   </AuthLink>
                 </p>
                 <p>
-                  <AuthLink href="/auth/signup">
+                  <AuthLink to="/auth/signup">
                     Don't have an account? <u>Sign Up</u>
                   </AuthLink>
                 </p>
               </>
             ) : (
               <p>
-                <AuthLink href="/auth/login">
+                <AuthLink to="/auth/login">
                   Already have an account? <u>Sign In</u>
                 </AuthLink>
               </p>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,5 +1,6 @@
 import { Button, Flex, WhiteSpace, Toast } from "antd-mobile";
 import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
 
@@ -175,63 +176,25 @@ const VisibilityButton = ({ onClick, type }) => {
 
 const Login = ({ isLoginForm }) => {
   const dispatch = useDispatch();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const { register, handleSubmit, errors } = useForm();
   const [passwordType, setPasswordType] = useState("password");
-  const [confirmPassword, setConfirmPassword] = useState("");
   const [confirmPasswordType, setConfirmPasswordType] = useState("password");
   const queryParams = useQuery();
   const code = queryParams.get("code");
   const state = queryParams.get("state");
+
   useEffect(() => {
     if (code && state) {
       dispatch(authWithSocialProvider({ code, state }));
     }
   }, [code, state, dispatch]);
 
-  const handleInputChangeEmail = (e) => {
-    setEmail(e.target.value);
+  const onLoginWithEmail = (formData) => {
+    dispatch(loginWithEmail(formData));
   };
 
-  const handleInputChangePassword = (e) => {
-    setPassword(e.target.value);
-  };
-
-  const handleInputChangeConfirmPassword = (e) => {
-    setConfirmPassword(e.target.value);
-  };
-
-  const handleLoginWithEmail = (evt) => {
-    evt.preventDefault();
-    if (!validateEmail(email)) {
-      Toast.fail("Invalid email address!", 3);
-      return;
-    }
-    if (password.length < PASSWORD_MIN_LENGTH) {
-      Toast.fail("Password must be at least 6 characters", 3);
-      return;
-    }
-    dispatch(loginWithEmail({ email, password }));
-  };
-
-  const handleSignup = (evt) => {
-    evt.preventDefault();
-    // todo: add inline validation (disable button / indicate error on form)
-    if (!validateEmail(email)) {
-      Toast.fail("Invalid email address!", 3);
-      return;
-    }
-    // todo: add inline validation (disable button / indicate error on form)
-    if (password.length < PASSWORD_MIN_LENGTH) {
-      Toast.fail("Password must be at least 6 characters", 3);
-      return;
-    }
-    // todo: check if passwords are the same (dissable button / indicate error on form)
-    if (password !== confirmPassword) {
-      Toast.fail("Password and confirm password do not match!", 3);
-      return;
-    }
-    dispatch(signup({ email, password, confirmPassword }));
+  const onSignup = (formData) => {
+    dispatch(signup(formData));
   };
 
   const handleSocialLogin = (provider) => {
@@ -271,7 +234,7 @@ const Login = ({ isLoginForm }) => {
             <Heading className="h4" level={4}>
               {isLoginForm ? "Sign In" : "Sign Up"}
             </Heading>
-            <form id="login-password" method="POST">
+            <form id="login-password">
               <InputWrapper>
                 <Label for="email" style={StyleLabel} label="E-mail" />
                 <Input
@@ -279,8 +242,7 @@ const Login = ({ isLoginForm }) => {
                   name="email"
                   required
                   placeholder="Enter email address"
-                  value={email}
-                  onChange={handleInputChangeEmail}
+                  ref={register}
                   style={StyleInput}
                 />
               </InputWrapper>
@@ -292,8 +254,7 @@ const Login = ({ isLoginForm }) => {
                   id="password"
                   required
                   placeholder="Enter password"
-                  value={password}
-                  onChange={handleInputChangePassword}
+                  ref={register}
                   style={StyleInput}
                 />
                 <VisibilityButton
@@ -314,8 +275,7 @@ const Login = ({ isLoginForm }) => {
                     id="confirmPassword"
                     required
                     placeholder="Confirm password"
-                    onChange={handleInputChangeConfirmPassword}
-                    value={confirmPassword}
+                    ref={register}
                     style={StyleInput}
                   />
                   <VisibilityButton
@@ -326,7 +286,7 @@ const Login = ({ isLoginForm }) => {
               )}
               <SubmitButton
                 primary="true"
-                onClick={isLoginForm ? handleLoginWithEmail : handleSignup}
+                onClick={isLoginForm ? handleSubmit(onLoginWithEmail) : handleSubmit(onSignup)}
               >
                 {isLoginForm ? "Sign In" : "Sign Up"}
               </SubmitButton>

--- a/client/src/reducers/sessionReducer.js
+++ b/client/src/reducers/sessionReducer.js
@@ -1,8 +1,6 @@
 import {
-  AUTH_LOGIN,
   AUTH_LOGOUT,
-  AUTH_SIGNUP,
-  SET_USER,
+  AUTH_SUCCESS,
 } from "constants/action-types";
 
 const initialState = {
@@ -13,8 +11,7 @@ const initialState = {
 
 function sessionReducer(state = initialState, action) {
   switch (action.type) {
-    case AUTH_LOGIN:
-    case AUTH_SIGNUP:
+    case AUTH_SUCCESS:
       return {
         ...state,
         accessToken: action.payload.token,
@@ -24,13 +21,7 @@ function sessionReducer(state = initialState, action) {
     case AUTH_LOGOUT:
       return {
         ...state,
-        accessToken: null,
-        isAuthenticated: false,
-      };
-    case SET_USER:
-      return {
-        ...state,
-        user: action.payload,
+        initialState,
       };
     default:
       return state;


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fixes #370 and #372 
I've refactored the form to use `react-hook-form` so we don't have to code all the validation etc. manually, and I think we should use this same library consistently for most of the forms in the app.

This means I've also already done part of the work of #409 except for the styling.
The `react-hook-form` has integrated validation and errors, currently disabling the submit button if any input is not valid.

I've disabled the client-side email validation for now, I think that function will need to be changed, we can just pass the regex to the validator directly instead I think, we could also pass the function to the `validate` prop ... but out of scope here so maybe it can also be integrated with #409 

For redux & useReducer hook, I've done most of the form validation with the `useReducer` without Redux, only the `isAuthenticated` is still using redux, including the `emailVerified` and the next step is to add the user in the response & integrate with "create user profile" page. 

I think it might be a good idea to remove redux completely to avoid confusion with `useReducer` actions & reducers, and use the context API instead for the authenticated user data... feedback welcome ofcourse.