### PR TITLE
feat: add optional authentication decorator in fastify for API #411

### DIFF
--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -24,8 +24,7 @@ const getPostsSchema = {
         .prop("objective", S.string().enum(POST_OBJECTIVES)),
     )
     .prop("limit", S.integer())
-    .prop("skip", S.integer())
-    .prop("userId", S.string()),
+    .prop("skip", S.integer()),
 };
 
 const createPostSchema = {


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Closes #411 
Add an additional decorator in the Fastify auth plugin, `authenticateOptional` that doesn't return a `401 Unauthorized` if there is no Authorization header with JWT in the request, but instead it optionally decodes the token to get user id, and otherwise just allows the request without doing anything.

This moves any possible authorization logic to the other handlers, for example I've updated the  `GET /api/posts` a bit to use this handler, but it will have to be further implemented to adjust the right query to mongo db to use this functionality ( cc @Naraujo13  @joaofnds )