### PR TITLE
upgrade moment to ^2.25.3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12339,9 +12339,9 @@
       }
     },
     "moment": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
-      "integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "jwt-decode": "^2.2.0",
-    "moment": "^2.25.1",
+    "moment": "^2.25.3",
     "polished": "^3.5.2",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

fix https://github.com/moment/moment/issues/5484# by upgrade to moment ^2.25.3 (installs 2.26.0).

Resolves #450 