### PR TITLE
Bugfix: error handler - pass proper error object to Sentry

### DIFF
--- a/backend/lib/plugins/error-handler.js
+++ b/backend/lib/plugins/error-handler.js
@@ -21,7 +21,7 @@ function errorNotifierHandler(error, request, reply) {
       ip_address: request.raw.ip,
     });
     scope.setTag("path", request.raw.url);
-    Sentry.captureException(err);
+    Sentry.captureException(error);
     defaultErrorHandler(error, request, reply);
   });
 }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fix the call to Sentry by passing in `error` instead of `err`
