### PR TITLE
Fix bug in error handling

### DIFF
--- a/backend/lib/plugins/error-handler.js
+++ b/backend/lib/plugins/error-handler.js
@@ -5,6 +5,8 @@ const Sentry = require("@sentry/node");
 // https://github.com/fastify/fastify-sensible/blob/5eec059b2a77579f75bafc91e12f60fb90b6dab5/index.js#L46
 function defaultErrorHandler(error, request, reply) {
   if (
+    reply &&
+    reply.raw &&
     reply.raw.statusCode === 500 &&
     error.explicitInternalServerError !== true
   ) {


### PR DESCRIPTION
I was having an issue with docker a proxy request error while trying to send requests to the backend from the client. After talking with @mannykary he discovered that there was a bug in the new error plugin he installed. This fixes that bug. 
