### PR TITLE
Add pagination to /posts endpoint

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -25,6 +25,7 @@ async function routes(app) {
   const User = mongo.model("User");
 
   // /posts
+  const POST_PAGE_SIZE = 5;
   const UNLOGGED_POST_SIZE = 120;
   const EXPIRATION_OPTIONS = ["day", "week", "month"];
 
@@ -36,6 +37,7 @@ async function routes(app) {
     },
     async (req) => {
       const { userId } = req;
+      const { limit, filter: paramFilters, skip } = req.query;
       let user;
       let userErr;
       if (userId) {
@@ -75,7 +77,6 @@ async function routes(app) {
       /* eslint-enable sort-keys */
 
       // Additional filters
-      const { paramFilters } = req.params;
       if (paramFilters) {
         // TODO: additional filters
       }
@@ -118,6 +119,12 @@ async function routes(app) {
 
       const aggregationPipeline = [
         ...sortAndFilterSteps,
+        {
+          $skip: skip || 0,
+        },
+        {
+          $limit: limit || POST_PAGE_SIZE,
+        },
         {
           $lookup: {
             as: "comments",


### PR DESCRIPTION
### What does this pull request aim to achieve? 

Add pagination to `/posts` endpoints with standard page size of 5 records.

Closes #126 

This is a simple pagination method using `skip` and `limit`.
It was discussed at #197 about using other pagination methods to avoid possible duplicates when a record is added and changes the record order (e.g. a record added that would be on the first page because is near the user, pushes the fifth record to sixth, making it to be displayed again when fetching the second page). Since this shouldn't happen frequently and the effect is not that big for the user (just single repeated post), I'm submitting this simpler version for MVP and we can discuss and improve it later on.
