### PR TITLE
Send only 500 errors to Sentry

### DIFF
--- a/backend/lib/plugins/error-handler.js
+++ b/backend/lib/plugins/error-handler.js
@@ -1,15 +1,19 @@
 const fp = require("fastify-plugin");
 const Sentry = require("@sentry/node");
 
-// Default Fastify-Sensible error handler
-// https://github.com/fastify/fastify-sensible/blob/5eec059b2a77579f75bafc91e12f60fb90b6dab5/index.js#L46
-function defaultErrorHandler(error, request, reply) {
-  if (
+function isInternalServerError(error, reply) {
+  return (
     reply &&
     reply.raw &&
     reply.raw.statusCode === 500 &&
     error.explicitInternalServerError !== true
-  ) {
+  );
+}
+
+// Default Fastify-Sensible error handler
+// https://github.com/fastify/fastify-sensible/blob/5eec059b2a77579f75bafc91e12f60fb90b6dab5/index.js#L46
+function defaultErrorHandler(error, request, reply) {
+  if (isInternalServerError(error, reply)) {
     request.log.error(error);
     reply.send(new Error("Something went wrong"));
   } else {
@@ -19,11 +23,13 @@ function defaultErrorHandler(error, request, reply) {
 
 function errorNotifierHandler(error, request, reply) {
   Sentry.withScope((scope) => {
-    scope.setUser({
-      ip_address: request.raw.ip,
-    });
-    scope.setTag("path", request.raw.url);
-    Sentry.captureException(error);
+    if (isInternalServerError(error, reply)) {
+      scope.setUser({
+        ip_address: request.raw.ip,
+      });
+      scope.setTag("path", request.raw.url);
+      Sentry.captureException(error);
+    }
     defaultErrorHandler(error, request, reply);
   });
 }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

All errors, including 4xx errors for bad request or unauthorized, are being sent to Sentry. This will become very noisy in production. Instead, we should only send 500 errors to Sentry.

I refactored the check that was used in `defaultErrorHandler` to a new function `isInternalServerError`, so that it can be used in `errorNotifierHandler`.
