### PR TITLE
[529] Give Help page - checkboxes toggle fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /data
 /geo-service/venv
 **/node_modules
+.idea/
 .vscode
 .terraform
 backend.tf

--- a/client/src/components/StepWizard/index.js
+++ b/client/src/components/StepWizard/index.js
@@ -1,6 +1,6 @@
 export { default as AnswerButton } from "./AnswerButton";
 export { default as AnswerCheckbox } from "./AnswerCheckbox";
-export { getAnswersMap, getCheckedAnswers } from "./stepWizardUtils";
+export { checkSingleAnswer, getAnswersMap, getCheckedAnswers} from "./stepWizardUtils";
 export { default as StyledWizard } from "./StyledWizard";
 export { default as WizardContainer } from "./WizardContainer";
 export { default as WizardNav } from "./WizardNav";

--- a/client/src/components/StepWizard/stepWizardUtils.js
+++ b/client/src/components/StepWizard/stepWizardUtils.js
@@ -11,3 +11,15 @@ export const getCheckedAnswers = (answersMap) =>
   Object.entries(answersMap)
     .filter(([, checked]) => checked)
     .map(([answer]) => answer);
+
+
+export const checkSingleAnswer = (answersMap, checkedAnswer) =>
+    Object.entries(answersMap)
+        .map(([answer,]) => {
+            if (answer === checkedAnswer) {
+                return [answer, true]
+            }
+            else {
+                return [answer, false]
+            }
+        })

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -17,6 +17,7 @@ import {
   WizardProgress,
   WizardFormWrapper,
   WizardFormGroup,
+  checkSingleAnswer,
   getAnswersMap,
   getCheckedAnswers,
   WizardCheckboxWrapper,
@@ -47,7 +48,7 @@ const Step1 = (props) => {
   const { answers, none } = state;
 
   const toggleAnswer = (answer) => {
-    const updatedAnswers = { ...answers, [answer]: !answers[answer] };
+    const updatedAnswers = Object.fromEntries(checkSingleAnswer(answers, answer));
     const checkedAnswers = getCheckedAnswers(updatedAnswers);
     updateState({ ...state, answers: updatedAnswers });
     props.update("helpTypeOffered", checkedAnswers);
@@ -61,11 +62,11 @@ const Step1 = (props) => {
       <StepTitle>How do you want to contribute?</StepTitle>
       <WizardFormWrapper>
         <WizardCheckboxWrapper>
-          {Object.entries(answers).map(([answer, checked], i) => (
+          {Object.entries(answers).map(([answer], i) => (
             <WizardCheckboxItem
               key={i}
               onChange={() => toggleAnswer(answer)}
-              checked={!none && checked}
+              checked={!none && state.answers[answer]}
             >
               {answer}
             </WizardCheckboxItem>
@@ -115,7 +116,7 @@ const Step2 = (props) => {
         </WizardFormGroup>
         <ShareLocation
           tertiary="true"
-          icon={<SvgIcon class="share-location-icon" src={shareMyLocation} />}
+          icon={<SvgIcon className="share-location-icon" src={shareMyLocation} />}
           onSelect={selectLocationDetection}
         >
           Share my location


### PR DESCRIPTION
## Related Issue [529](https://github.com/FightPandemics/FightPandemics/issues/529)

## Previous behavior:
In the "**How do you want to contribut**e" section of the "**Give Help**" page, the user could check several boxes and the checks did not toggle once a new option was clicked.
![](https://i.imgur.com/84YSFOm.png)
## New behavior:
The user can only select one checkbox.
![](https://i.imgur.com/dAFdJVe.gif)

Closes #529 
### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
