### PR TITLE
[529] In the "Give Help" page, clicking divs with text options toggles the checkboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /data
 /geo-service/venv
 **/node_modules
+.idea/
 .vscode
 .terraform
 backend.tf

--- a/client/src/components/StepWizard/WizardCheckboxItem.js
+++ b/client/src/components/StepWizard/WizardCheckboxItem.js
@@ -25,13 +25,16 @@ const CheckboxItemStyles = styled.div`
   padding: 2rem;
   margin-bottom: 1rem;
   width: 100%;
+  cursor: pointer;
 
   .am-list-line {
     &:after {
       background-color: unset !important;
     }
+  } 
+  .am-checkbox-input {
+    cursor: pointer; 
   }
-
   .am-checkbox-inner {
     border-radius: 0.5px;
     border: 0.1rem solid ${lightGray};

--- a/client/src/components/StepWizard/WizardCheckboxItem.js
+++ b/client/src/components/StepWizard/WizardCheckboxItem.js
@@ -3,7 +3,7 @@ import React from "react";
 import {Checkbox} from "antd-mobile";
 import {theme, mq} from "constants/theme";
 
-const {white, lightGray, royalBlue} = theme.colors;
+const {white, lightGray, royalBlue, black} = theme.colors;
 
 export const WizardCheckboxWrapper = styled.div`
   margin: 4rem auto;
@@ -43,7 +43,7 @@ const CheckboxItemStyles = styled.div`
     }
   }
    > .text {
-   color: #000;
+   color: ${black};
     flex-grow: 1;
     margin-left: 2rem;
   }

--- a/client/src/components/StepWizard/WizardCheckboxItem.js
+++ b/client/src/components/StepWizard/WizardCheckboxItem.js
@@ -1,10 +1,9 @@
 import styled from "styled-components";
-import { Checkbox } from "antd-mobile";
-import { theme, mq } from "constants/theme";
+import React from "react";
+import {Checkbox} from "antd-mobile";
+import {theme, mq} from "constants/theme";
 
-const { white, lightGray, royalBlue } = theme.colors;
-
-const CheckboxItem = Checkbox.CheckboxItem;
+const {white, lightGray, royalBlue} = theme.colors;
 
 export const WizardCheckboxWrapper = styled.div`
   margin: 4rem auto;
@@ -19,10 +18,11 @@ export const WizardCheckboxWrapper = styled.div`
   }
 `;
 
-export const WizardCheckboxItem = styled(CheckboxItem)`
+const CheckboxItemStyles = styled.div`
   font-family: ${theme.typography.font.family.display};
   font-size: ${theme.typography.size.large};
   background-color: ${white};
+  padding: 2rem;
   margin-bottom: 1rem;
   width: 100%;
 
@@ -42,6 +42,11 @@ export const WizardCheckboxItem = styled(CheckboxItem)`
       width: 0.7rem;
     }
   }
+   > .text {
+   color: #000;
+    flex-grow: 1;
+    margin-left: 2rem;
+  }
 
   .am-checkbox.am-checkbox-checked .am-checkbox-inner {
     border-color: ${royalBlue};
@@ -54,3 +59,16 @@ export const WizardCheckboxItem = styled(CheckboxItem)`
     height: 6rem;
   }
 `;
+
+export const WizardCheckboxItem = ({text, checked, onChange, ...props}) => {
+    return (
+        <CheckboxItemStyles
+            onClick={onChange}
+            className={checked && "selected"}
+            {...props}
+        >
+            <Checkbox checked={checked}/>
+            <span className="text">{text}</span>
+        </CheckboxItemStyles>
+    );
+};

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -69,7 +69,7 @@ const Step1 = (props) => {
               text={answer}
             />
           ))}
-          </WizardCheckboxWrapper>
+        </WizardCheckboxWrapper>
       </WizardFormWrapper>
     </WizardStep>
   );

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -66,11 +66,10 @@ const Step1 = (props) => {
               key={i}
               onChange={() => toggleAnswer(answer)}
               checked={!none && checked}
-            >
-              {answer}
-            </WizardCheckboxItem>
+              text={answer}
+            />
           ))}
-        </WizardCheckboxWrapper>
+          </WizardCheckboxWrapper>
       </WizardFormWrapper>
     </WizardStep>
   );
@@ -115,7 +114,7 @@ const Step2 = (props) => {
         </WizardFormGroup>
         <ShareLocation
           tertiary="true"
-          icon={<SvgIcon class="share-location-icon" src={shareMyLocation} />}
+          icon={<SvgIcon className="share-location-icon" src={shareMyLocation} />}
           onSelect={selectLocationDetection}
         >
           Share my location


### PR DESCRIPTION
## Previously:
In the "Give Help" page, on section 1/3, the user was not able to toggle the checkboxes when clicking the option divs:
![before](https://user-images.githubusercontent.com/6276256/83405412-0e141400-a42a-11ea-9c8b-f26324ca6635.gif)

## Now:

The user can now click on the option divs to toggle the checkboxes.

The Ant Design `Checkbox.CheckboxItem` component was preventing the div clicks from bubbling up and toggling the checkboxes. I removed `Checkbox.CheckboxItem` and now the `WizardCheckboxItem` component uses Ant Design's `Checkbox` component.  I used `AnswerCheckbox`'s implementation for guidance. 

![now](https://i.imgur.com/4ICqeez.gif)


Closes #529
### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
