### PR TITLE
[537] Email validation fix - validate email top-level domains on sign-up

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -63,9 +63,6 @@
     "lint-staged": "^10.2.0",
     "prettier": "^2.0.5"
   },
-  "optionalDependencies": {
-    "fsevents": "*"
-  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "snyk": "^1.319.2",
     "styled-components": "^5.0.1",
     "super-tiny-icons": "^0.3.2",
+    "tlds": "^1.207.0",
     "typeface-poppins": "^0.0.72",
     "typeface-work-sans": "^0.0.72"
   },
@@ -61,6 +62,9 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.0",
     "prettier": "^2.0.5"
+  },
+  "optionalDependencies": {
+    "fsevents": "*"
   },
   "husky": {
     "hooks": {

--- a/client/src/utils/validators.js
+++ b/client/src/utils/validators.js
@@ -1,4 +1,17 @@
+import tlds from 'tlds';
+
+const validateTopLevelDomain = (email) => {
+    for (const tld of tlds) {
+      if (email.endsWith('.' + tld)) {
+        return true;
+      }
+    }
+    return false;
+};
 export const validateEmail = (email) => {
   const re = /^(([^<>()\]\\.,;:\s@"]+(\.[^<>()\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(email).toLowerCase());
+  const emailInput = String(email).toLowerCase();
+  const isEmailValid = re.test(emailInput);
+
+  return isEmailValid ? validateTopLevelDomain(emailInput) : false;
 };


### PR DESCRIPTION
## Previously:
Our email validation did not check whether the email's top-level domain was valid. 
As described in #537, any top-level domain of length >= 2 was valid. 
![](https://i.imgur.com/fM24wMG.png)


## Now:
The user can submit the sign-up form if their email contains a valid top-level domain registered with [ICANN](https://www.icann.org/resources/pages/tlds-2012-02-25-en).

The `tlds` package contains an up-to-date list of valid top-level domains scraped from ICANN.
 You can check out the full list of top-level domains [here](https://github.com/stephenmathieson/node-tlds/blob/master/index.js). 
![](https://i.imgur.com/jur41vY.gif)

Closes #537 
## 