### PR TITLE
use post.author vars in post header

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -25,8 +25,8 @@ const Post = ({ isAuthenticated, post }) => {
   const [showComments, setShowComments] = useState(false);
   const [copied, setCopied] = useState(false);
   const AvatarName =
-    (post.authorName &&
-      post.authorName.match(/\b\w/g).join("").toUpperCase()) ||
+    (post.author.name &&
+      post.author.name.match(/\b\w/g).join("").toUpperCase()) ||
     "";
 
   // mock API to test functionality
@@ -81,9 +81,9 @@ const Post = ({ isAuthenticated, post }) => {
 
  const renderHeader = (
     <Card.Header
-      title={post.authorName}
+      title={post.author.name}
       thumb={
-        post.photoUrl ? post.photoUrl : <TextAvatar>{AvatarName}</TextAvatar>
+        post.author.photo ? post.author.photo : <TextAvatar>{AvatarName}</TextAvatar>
       }
       extra={
         <span>


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Uses correct variables from `post.author` for post header in feed. Resolves #566 

**Has photo**:

![image](https://user-images.githubusercontent.com/10546720/83669833-358ced00-a5a0-11ea-928f-0c02aff06d62.png)

**No photo**:

![image](https://user-images.githubusercontent.com/10546720/83669814-2a39c180-a5a0-11ea-804e-16680d753843.png)

There is still the backend issue of these not being updated when the user updates their own or org logo but this will be dealt with separately but before MVP launch.

### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
