### PR TITLE
Fix reference to commentSchema

### DIFF
--- a/backend/lib/models/Comment.js
+++ b/backend/lib/models/Comment.js
@@ -65,7 +65,7 @@ function updateAuthorType(authorID, newAuthorType) {
 
 module.exports = {
   model: Comment,
-  schema: CommentSchema,
+  schema: commentSchema,
   updateAuthorName,
   updateAuthorType,
 };


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

I noticed this error when I ran the latest code in master:
```
backend-service    | /app/lib/models/Comment.js:68
backend-service    |   schema: CommentSchema,
backend-service    |           ^
backend-service    | 
backend-service    | ReferenceError: CommentSchema is not defined
backend-service    |     at Object.<anonymous> (/app/lib/models/Comment.js:68:11)
backend-service    |     at Module._compile (internal/modules/cjs/loader.js:1133:30)
backend-service    |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
backend-service    |     at Module.load (internal/modules/cjs/loader.js:977:32)
backend-service    |     at Function.Module._load (internal/modules/cjs/loader.js:877:14)
backend-service    |     at Module.require (internal/modules/cjs/loader.js:1019:19)
backend-service    |     at require (internal/modules/cjs/helpers.js:77:18)
backend-service    |     at Object.<anonymous> (/app/lib/plugins/mongoose-connector.js:5:1)
backend-service    |     at Module._compile (internal/modules/cjs/loader.js:1133:30)
backend-service    |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
backend-service    |     at Module.load (internal/modules/cjs/loader.js:977:32)
backend-service    |     at Function.Module._load (internal/modules/cjs/loader.js:877:14)
backend-service    |     at Module.require (internal/modules/cjs/loader.js:1019:19)
backend-service    |     at require (internal/modules/cjs/helpers.js:77:18)
backend-service    |     at createApp (/app/lib/index.js:42:16)
backend-service    |     at Object.<anonymous> (/app/server.js:6:16)
```

This PR should fix the issue. Please merge ASAP once approved.
