### PR TITLE
fix: throw & log errors if  mongo id is not found in JWT

### DIFF
--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -112,6 +112,9 @@ async function routes(app) {
       const { email_verified: emailVerified } = auth0User;
       const { payload } = app.jwt.decode(token);
       const userId = payload[authConfig.jwtMongoIdKey];
+      if (!userId) {
+        throw new Error("no mongo_id found in JWT");
+      }
       const dbUser = await User.findById(userId);
       let user = null;
       if (dbUser) {
@@ -128,7 +131,7 @@ async function routes(app) {
       if (err.statusCode === 403) {
         throw app.httpErrors.unauthorized("Wrong email or password.");
       }
-      req.log.error("Error logging in", { err });
+      req.log.error(err, "Error logging in");
       throw app.httpErrors.internalServerError();
     }
   });

--- a/backend/lib/endpoints/users.js
+++ b/backend/lib/endpoints/users.js
@@ -47,6 +47,10 @@ async function routes(app) {
       if (!emailVerified) {
         throw app.httpErrors.forbidden("Email address not verified");
       }
+      if (!req.userId) {
+        req.log.error("No userId for create user, invalid configuration", { email });
+        throw app.httpErrors.internalServerError();
+      }
       if (await User.findById(req.userId)) {
         throw app.httpErrors.conflict("User exists");
       }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

fixes #572 
throw & log errors if no mongo id found in JWT, to prevent creating users if the app or Auth0 is not correctly configured