### PR TITLE
Fix for issue 581 - Setting overflow-y to 'auto'

### DIFF
--- a/client/src/components/CreatePost/StyledPostAs.js
+++ b/client/src/components/CreatePost/StyledPostAs.js
@@ -36,7 +36,7 @@ const Container = styled(Modal)`
   .ant-modal-body {
     display: flex;
     max-height: 49.6rem;
-    overflow-y: scroll;
+    overflow-y: auto;
     padding: 3.8rem 4rem 4.7rem 4rem;
     min-height: 25.7rem;
     flex-direction: column;


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fix fot the issue [581](https://github.com/FightPandemics/FightPandemics/issues/581) by setting the overflow-y to auto.

### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
