### PR TITLE
fix redirect for give help skip email opt

### DIFF
--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -168,7 +168,7 @@ const Step3 = (props) => {
           Submit
           </WizardButton>
         <SkipLink>
-          <Link to="/AirTableCOVID">
+          <Link to="/feed">
             {/* By clicking on “skip”, users can skip the landing questions to see the information directly */}
             Skip
             </Link>


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
As of now, this just adds a redirect to /feed when a user wants to offer help chooses to skip providing an email
_Please be concise and link any related issue(s):_
#604 

Note: We can merge this PR for now but leave the issue open so later we can integrate the filters as well. 