### PR TITLE
[606] Password recovery endpoint: Sends user an email with a change password ticket to update password 

### DIFF
--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -113,12 +113,6 @@ const changePassword = async (token, email) => {
     );
     return res.data;
   } catch (err) {
-    console.log(
-      "ERR HERE",
-      err,
-      AUTH_DOMAIN,
-      JSON.stringify(config.auth.clientId),
-    );
     return wrapError(err);
   }
 };

--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -85,9 +85,36 @@ const getUser = async (token) => {
   }
 };
 
+const getUserByEmail = async (token) => {
+  try {
+    const res = await axios.get(
+      `${AUTH_DOMAIN}/api/v2/users-by-email`,
+      getAuthHeaders(token),
+    );
+    return res.data;
+  } catch (err) {
+    return wrapError(err);
+  }
+};
+
+const changePassword = async (token, payload) => {
+  try {
+    const res = await axios.post(
+      `${AUTH_DOMAIN}/api/v2/tickets/password-change`,
+      payload,
+      getAuthHeaders(token),
+    );
+    return res.data;
+  } catch (err) {
+    return wrapError(err);
+  }
+};
+
 module.exports = {
   authenticate,
   buildOauthUrl,
+  changePassword,
   createUser,
   getUser,
+  getUserByEmail,
 };

--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -85,10 +85,10 @@ const getUser = async (token) => {
   }
 };
 
-const getUserByEmail = async (token) => {
+const getUserByEmail = async (token, email) => {
   try {
     const res = await axios.get(
-      `${AUTH_DOMAIN}/api/v2/users-by-email`,
+      `${AUTH_DOMAIN}/api/v2/users-by-email?email=${email}`,
       getAuthHeaders(token),
     );
     return res.data;

--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -85,18 +85,6 @@ const getUser = async (token) => {
   }
 };
 
-const getUserByEmail = async (token, email) => {
-  try {
-    const res = await axios.get(
-      `${AUTH_DOMAIN}/api/v2/users-by-email?email=${email}`,
-      getAuthHeaders(token),
-    );
-    return res.data;
-  } catch (err) {
-    return wrapError(err);
-  }
-};
-
 const changePassword = async (token, email) => {
   const client_id = config.auth.clientId;
   const connection = "Username-Password-Authentication";
@@ -123,5 +111,4 @@ module.exports = {
   changePassword,
   createUser,
   getUser,
-  getUserByEmail,
 };

--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -97,15 +97,28 @@ const getUserByEmail = async (token, email) => {
   }
 };
 
-const changePassword = async (token, payload) => {
+const changePassword = async (token, email) => {
+  const client_id = config.auth.clientId;
+  const connection = "Username-Password-Authentication";
+  const payload = {
+    client_id,
+    email,
+    connection,
+  };
   try {
     const res = await axios.post(
-      `${AUTH_DOMAIN}/api/v2/tickets/password-change`,
+      `${AUTH_DOMAIN}/dbconnections/change_password`,
       payload,
       getAuthHeaders(token),
     );
     return res.data;
   } catch (err) {
+    console.log(
+      "ERR HERE",
+      err,
+      AUTH_DOMAIN,
+      JSON.stringify(config.auth.clientId),
+    );
     return wrapError(err);
   }
 };

--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -144,37 +144,20 @@ async function routes(app) {
       const { body, token } = req;
       const { email } = body;
 
-      const ttl_sec = 300; //5 minutes
-      const result_url = req.headers.referer;
-      const includeEmailInRedirect = true;
-
       try {
-        const getUser = await Auth0.getUserByEmail(token, email);
-        const { user_id } = getUser[0];
-        if (!user_id) {
-          throw app.httpErrors.badRequest(err, `User ${email} does not exist`);
-        }
-        const payload = {
-          result_url,
-          ttl_sec,
-          user_id,
-          includeEmailInRedirect,
-        };
-        const changePasswordTicket = await Auth0.changePassword(token, payload);
-        const { ticket } = changePasswordTicket;
-
+        const responseMessage = await Auth0.changePassword(token, email);
         req.log.info(
-          `Change password ticket created successfully for email=${email}`,
+          `Change password email created successfully for email=${email}`,
         );
-        return { ticket };
+        return { email, responseMessage, token };
       } catch (err) {
         if (err.statusCode === 400) {
           throw app.httpErrors.badRequest(err, `User ${email} does not exist`);
         } else if (err.statusCode === 404) {
           throw app.httpErrors.notFound(err, `User ${email} not found`);
         }
-        req.log.error(err, "Error creating change password ticket");
-        throw app.httpErrors.internalServerError();
+        req.log.error(err, "Error creating change password email");
+        throw app.httpErrors.internalServerError(`Error creating change password email=${email}`);
       }
     },
   );

--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -1,5 +1,6 @@
 const Auth0 = require("../components/Auth0");
 const {
+  changePasswordSchema,
   loginSchema,
   oAuthSchema,
   oAuthProviderSchema,
@@ -135,6 +136,43 @@ async function routes(app) {
       throw app.httpErrors.internalServerError();
     }
   });
-}
+
+app.post("/change-password", { preHandler: [app.getServerToken],  schema: changePasswordSchema }, async (req) => {
+
+    const { body, token } = req;
+    const { email } = body;
+    const ttl_sec = 300; //5 minutes
+
+
+    try {
+      const getUser = await Auth0.getUserByEmail(token)
+      const { user_id } = getUser;
+      const payload = {
+        user_id,
+        ttl_sec,
+      }
+    } catch (err) {
+      throw app.httpErrors.badRequest(err); //general catch-all for now
+    }
+
+    
+    try {
+      const changePasswordTicket = await Auth0.changePassword(token, payload);
+      const { ticket } = changePasswordTicket;
+      req.log.info(`Change password ticket created successfully for email=${email}`);
+    } catch (err) {
+      if (err.statusCode === 400) {
+        throw app.httpErrors.badRequest(err, `User ${email} does not exist`);
+      } else if (err.statusCode === 404) {
+        throw app.httpErrors.notFound(err, `User ${email} not found`);
+      } 
+      req.log.error(err , "Error creating change password ticket");
+      throw app.httpErrors.internalServerError();
+    }
+    
+    return { ticket };
+
+  });
+};
 
 module.exports = routes;

--- a/backend/lib/endpoints/auth.js
+++ b/backend/lib/endpoints/auth.js
@@ -149,15 +149,12 @@ async function routes(app) {
         req.log.info(
           `Change password email created successfully for email=${email}`,
         );
-        return { email, responseMessage, token };
+        return { email, responseMessage };
       } catch (err) {
-        if (err.statusCode === 400) {
-          throw app.httpErrors.badRequest(err, `User ${email} does not exist`);
-        } else if (err.statusCode === 404) {
-          throw app.httpErrors.notFound(err, `User ${email} not found`);
-        }
         req.log.error(err, "Error creating change password email");
-        throw app.httpErrors.internalServerError(`Error creating change password email=${email}`);
+        throw app.httpErrors.internalServerError(
+          `Error creating change password email=${email}`,
+        );
       }
     },
   );

--- a/backend/lib/endpoints/schema/auth.js
+++ b/backend/lib/endpoints/schema/auth.js
@@ -15,6 +15,11 @@ const signupSchema = {
     .prop("confirmPassword", S.string().required()),
 };
 
+const changePasswordSchema = {
+  body: strictSchema()
+    .prop("email", S.string().required())
+};
+
 const oAuthSchema = {
   body: strictSchema()
     .prop("code", S.string().required())
@@ -29,6 +34,7 @@ const oAuthProviderSchema = {
 };
 
 module.exports = {
+  changePasswordSchema,
   loginSchema,
   oAuthProviderSchema,
   oAuthSchema,


### PR DESCRIPTION
This `api/auth/change-password` endpoint makes a POST to Auth0's `/dbconnections/change_password`
https://auth0.com/docs/api/authentication#change-password to send a  change password email and ticket to the email provided. 


Test curl POST request:

```
curl -X POST \
  http://localhost:3000/api/auth/change-password \
  -H 'accept: application/json, text/plain, */*' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json;charset=UTF-8' \
  -H 'postman-token: {POSTMAN TOKEN}' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36' \
  -d '{"email":"{YOUR EMAIL}"}'
```

Response:  
```
{
    "email": "bleh@mail.com",
    "responseMessage": "We've just sent you an email to reset your password.",
    "token": ""
}


```

Password reset flow and email template sent:
https://auth0.com/docs/connections/database/password-change

Closes #606 

