### PR TITLE
Define and export enum options instead of getting them from schema tree

### DIFF
--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -1,14 +1,13 @@
 const S = require("fluent-schema");
 const { strictSchema } = require("./utils");
 
-const { schema: authorSchema } = require("../../models/Author");
-const { schema: postSchema } = require("../../models/Post");
-
-const EXPIRATION_OPTIONS = ["day", "week", "month", "forever"];
-const POST_OBJECTIVES = postSchema.tree.objective.enum;
-const POST_TYPES = postSchema.tree.types.enum;
-const USER_TYPES = authorSchema.tree.type.enum;
-const VISIBILITY_OPTIONS = postSchema.tree.visibility.enum;
+const { USER_TYPES } = require("../../models/Author");
+const {
+  EXPIRATION_OPTIONS,
+  POST_OBJECTIVES,
+  POST_TYPES,
+  VISIBILITY_OPTIONS,
+} = require("../../models/Post");
 
 const getPostsSchema = {
   querystring: strictSchema()

--- a/backend/lib/models/Author.js
+++ b/backend/lib/models/Author.js
@@ -2,6 +2,19 @@
 const { Schema, model, ObjectId } = require("mongoose");
 const { schema: locationSchema } = require("./Location");
 
+const USER_TYPES = [
+  "Company",
+  "Community",
+  "Government",
+  "Health care provider",
+  "Individual",
+  "Non-profit",
+  "Other",
+  "R&D",
+  "Startup",
+  "University",
+];
+
 // -- Schema
 const authorSchema = new Schema({
   id: {
@@ -16,18 +29,7 @@ const authorSchema = new Schema({
   },
   photo: String,
   type: {
-    enum: [
-      "Company",
-      "Community",
-      "Government",
-      "Health care provider",
-      "Individual",
-      "Non-profit",
-      "Other",
-      "R&D",
-      "Startup",
-      "University",
-    ],
+    enum: USER_TYPES,
     required: true,
     trim: true,
     type: String,
@@ -37,5 +39,8 @@ const authorSchema = new Schema({
 // -- Model
 const Author = model("Author", authorSchema);
 
-exports.schema = authorSchema;
-exports.model = Author;
+module.exports = {
+  USER_TYPES,
+  model: Author,
+  schema: authorSchema,
+};

--- a/backend/lib/models/Location.js
+++ b/backend/lib/models/Location.js
@@ -1,5 +1,7 @@
 const { Schema, model } = require("mongoose");
 
+const LOCATION_TYPES = ["Point"];
+
 const locationSchema = new Schema({
   address: {
     lowercase: true,
@@ -42,7 +44,7 @@ const locationSchema = new Schema({
   },
   type: {
     default: "Point",
-    enum: ["Point"],
+    enum: LOCATION_TYPES,
     required: true,
     type: String,
   },
@@ -53,8 +55,6 @@ const locationSchema = new Schema({
 });
 
 const Location = model("Location", locationSchema);
-
-const LOCATION_TYPES = locationSchema.tree.type.enum;
 
 module.exports = {
   LOCATION_TYPES,

--- a/backend/lib/models/Post.js
+++ b/backend/lib/models/Post.js
@@ -1,6 +1,24 @@
 // -- Imports
 const { Schema, model, ObjectId } = require("mongoose");
 
+const EXPIRATION_OPTIONS = ["day", "week", "month", "forever"];
+const VISIBILITY_OPTIONS = ["city", "country", "state", "worldwide"];
+const POST_OBJECTIVES = ["request", "offer"];
+const POST_TYPES = [
+  "Business",
+  "Education",
+  "Entertainment",
+  "Funding",
+  "Groceries/Food",
+  "Information",
+  "Legal",
+  "Medical Supplies",
+  "R&D",
+  "Others",
+  "Wellbeing/Mental",
+  "Tech",
+];
+
 // -- Schema
 const postSchema = new Schema(
   {
@@ -26,7 +44,7 @@ const postSchema = new Schema(
       type: [ObjectId],
     },
     objective: {
-      enum: ["request", "offer"],
+      enum: POST_OBJECTIVES,
       lowercase: true,
       required: true,
       trim: true,
@@ -38,25 +56,12 @@ const postSchema = new Schema(
       type: String,
     },
     types: {
-      enum: [
-        "Business",
-        "Education",
-        "Entertainment",
-        "Funding",
-        "Groceries/Food",
-        "Information",
-        "Legal",
-        "Medical Supplies",
-        "R&D",
-        "Others",
-        "Wellbeing/Mental",
-        "Tech",
-      ],
+      enum: POST_TYPES,
       trim: true,
       type: [String],
     },
     visibility: {
-      enum: ["city", "country", "state", "worldwide"],
+      enum: VISIBILITY_OPTIONS,
       lowercase: true,
       trim: true,
       type: String,
@@ -180,6 +185,10 @@ function updateAuthorType(authorID, newAuthorType) {
 }
 
 module.exports = {
+  EXPIRATION_OPTIONS,
+  POST_OBJECTIVES,
+  POST_TYPES,
+  VISIBILITY_OPTIONS,
   model: Post,
   schema: postSchema,
   updateAuthorName,


### PR DESCRIPTION
### What does this pull request aim to achieve?

Define and export model enums on model definition files