### PR TITLE
Fix for issue 564 - No borders in mobile homepage

### DIFF
--- a/client/src/components/Button/FeedbackButton.js
+++ b/client/src/components/Button/FeedbackButton.js
@@ -1,6 +1,6 @@
 import { Button } from "antd-mobile";
 import styled from "styled-components";
-import { theme, mq } from "constants/theme";
+import { theme } from "constants/theme";
 
 const { black, royalBlue, white } = theme.colors;
 

--- a/client/src/components/Button/FeedbackButton.js
+++ b/client/src/components/Button/FeedbackButton.js
@@ -1,6 +1,6 @@
 import { Button } from "antd-mobile";
 import styled from "styled-components";
-import { theme } from "constants/theme";
+import { theme, mq } from "constants/theme";
 
 const { black, royalBlue, white } = theme.colors;
 
@@ -16,8 +16,8 @@ const FeedbackButton = styled(Button)`
     background-color: ${royalBlue};
     color: ${white};
   }
-  &.am-button-ghost:before {
-    border: none;
+  &.am-button {
+    border: solid ${royalBlue} !important;
   }
 `;
 

--- a/client/src/components/Button/FeedbackButton.js
+++ b/client/src/components/Button/FeedbackButton.js
@@ -5,7 +5,6 @@ import { theme } from "constants/theme";
 const { black, royalBlue, white } = theme.colors;
 
 const FeedbackButton = styled(Button)`
-  border: 0.2rem solid ${royalBlue};
   border-radius: 0.8rem;
   cursor: pointer;
   color: ${black};
@@ -16,8 +15,8 @@ const FeedbackButton = styled(Button)`
     background-color: ${royalBlue};
     color: ${white};
   }
-  &.am-button {
-    border: solid ${royalBlue} !important;
+  html body &.am-button {
+    border: 0.2rem solid ${royalBlue};
   }
 `;
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fix for [issue 564](https://github.com/FightPandemics/FightPandemics/issues/564)
Using !important to override specificity of the third party css border property in ant button. 
 
_Please be concise and link any related issue(s):_

### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
