### PR TITLE
use substrCP instead of substr

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -94,7 +94,7 @@ async function routes(app) {
               if: { $gt: [{ $strLenCP: "$content" }, UNLOGGED_POST_SIZE] },
               then: {
                 $concat: [
-                  { $substr: ["$content", 0, UNLOGGED_POST_SIZE] },
+                  { $substrCP: ["$content", 0, UNLOGGED_POST_SIZE] },
                   "...",
                 ],
               },


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #663 

This seems to address error:

```json
{
  "level": 50,
  "time": 1591740382050,
  "pid": 29,
  "hostname": "a612b4b6161a",
  "reqId": 3,
  "ok": 0,
  "errmsg": "$substrBytes:  Invalid range, ending index is in the middle of a UTF-8 character.",
  "code": 28657,
  "codeName": "Location28657",
  "name": "MongoError",
  "msg": "Failed requesting posts",
  "stack": "MongoError: $substrBytes:  Invalid range, ending index is in the middle of a UTF-8 character.\n    at MessageStream.messageHandler (/app/node_modules/mongoose/node_modules/mongodb/lib/cmap/connection.js:261:20)\n    at MessageStream.emit (events.js:315:20)\n    at MessageStream.EventEmitter.emit (domain.js:482:12)\n    at processIncomingData (/app/node_modules/mongoose/node_modules/mongodb/lib/cmap/message_stream.js:144:12)\n    at MessageStream._write (/app/node_modules/mongoose/node_modules/mongodb/lib/cmap/message_stream.js:42:5)\n    at doWrite (_stream_writable.js:403:12)\n    at writeOrBuffer (_stream_writable.js:387:5)\n    at MessageStream.Writable.write (_stream_writable.js:318:11)\n    at Socket.ondata (_stream_readable.js:717:22)\n    at Socket.emit (events.js:315:20)\n    at Socket.EventEmitter.emit (domain.js:482:12)\n    at addChunk (_stream_readable.js:295:12)\n    at readableAddChunk (_stream_readable.js:271:9)\n    at Socket.Readable.push (_stream_readable.js:212:10)\n    at TCP.onStreamRead (internal/stream_base_commons.js:186:23)",
  "type": "Error",
  "v": 1
}
```

### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
