### PR TITLE
Fixing button positioning in the wizard step navigation

### DIFF
--- a/client/src/components/StepWizard/StyledWizard.js
+++ b/client/src/components/StepWizard/StyledWizard.js
@@ -9,7 +9,9 @@ const StyledWizard = styled(StepWizard)`
   flex-direction: column-reverse;
   align-self: flex-start;
   width: 100%;
+  height: 100%;
   margin: 0 auto;
+  justify-content: space-between;
   @media screen and (min-width: ${tablet.narrow.minWidth}) {
     width: 40%;
   }

--- a/client/src/components/StepWizard/WizardNav.js
+++ b/client/src/components/StepWizard/WizardNav.js
@@ -18,17 +18,14 @@ const StyledWizardNav = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 1rem 0;
-  margin-bottom: 1rem;
+  margin: 0 auto 1rem;
   width: 35rem;
   max-width: 100%;
-  position: absolute;
-  top: 70%;
 
   & + div {
     display: flex;
     flex-flow: row wrap;
     max-height: calc(100% - 8rem); /* align-items: stretch; */
-
 
     & > div {
       min-height: 100%;
@@ -36,7 +33,6 @@ const StyledWizardNav = styled.div`
   }
 
   @media screen and (min-width: ${desktopBreakpoint}) {
-    margin: 0 auto 1rem;
     width: 40rem;
   }
 `;
@@ -102,12 +98,12 @@ const WizardNav = ({ currentStep, nextStep, previousStep, totalSteps }) => (
         <BackText>Back</BackText>
       </BackButton>
     ) : (
-      <BackButton>
-        <Link to={"/"}>
+      <Link to={"/"}>
+        <BackButton>
           <SvgIcon src={backArrow} title="Navigate to the homepage" />{" "}
           <BackText>Back</BackText>
-        </Link>
-      </BackButton>
+        </BackButton>
+      </Link>
     )}
     {currentStep < totalSteps && (
       <NextButton onClick={nextStep}>


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fix for issue [#671 ](https://github.com/FightPandemics/FightPandemics/issues/671)

`  justify-content: space-between;
`

Forcing the divs to keep the same distance between each other throughout the steps.

`<Link to={"/"}>
        <BackButton>
          [...]`

Putting the button inside the link element, because in the Step1, the button was moving up a little bit.
_Please be concise and link any related issue(s):_

### 🚨Before submitting this pull request🚨:

_Please do **NOT** submit this PR if you have not done the following:_

1. I have checked that no one else is working on similar changes.
2. I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
3. The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
4. This branch is rebased/merged with the **latest master**.
5. There are no merge conflicts.
6. There are no console warnings and errors.
7. On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".