### PR TITLE
Pass in required aws_region variable

### DIFF
--- a/.github/workflows/review-delete-workflow.yml
+++ b/.github/workflows/review-delete-workflow.yml
@@ -49,4 +49,5 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           TF_VAR_env_name: ${{ steps.get-branch-name-sanitized.outputs.branch }}
           TF_VAR_fp_context: review
+          TF_VAR_aws_region: us-east-1
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Review build delete workflows are broken because the terraform destroy command expects `aws_region` variable to be passed in, but none is passed in.