### PR TITLE
Add Google Tag Manager environment variable

### DIFF
--- a/.github/workflows/production-workflow.yml
+++ b/.github/workflows/production-workflow.yml
@@ -16,6 +16,12 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+      - if: matrix.app == 'client'
+        env:
+          GTM_ID: $ {{ secrets.PRODUCTION_GTM_ID }}
+        run: >
+          echo "REACT_APP_GTM_ID=${GTM_ID}" > ./client/.env
+          cat .env
       - name: docker
         uses: docker/build-push-action@v1.0.1
         with:

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -21,6 +21,12 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+      - if: matrix.app == 'client'
+        env:
+          GTM_ID: $ {{ secrets.STAGING_GTM_ID }}
+        run: >
+          echo "REACT_APP_GTM_ID=${GTM_ID}" > ./client/.env
+          cat .env
       - name: docker
         uses: docker/build-push-action@v1.0.1
         with:


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

The client container needs the Google Tag Manager environment variable set for tracking/analytics. So we need to inject the variables from Github Secrets into the `.env` file when building the container.

This is required only for staging/production. The review environment does not need this set.

Fixes #699 .