### PR TITLE
refactored code to remove console warnings

### DIFF
--- a/client/src/pages/AboutUs.js
+++ b/client/src/pages/AboutUs.js
@@ -84,7 +84,7 @@ const supporterLogos = [
 function LogoItem(props) {
   return (
     <div>
-      <img src={props.value} />
+      <img src={props.value} alt="" />
     </div>
   );
 }

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -332,7 +332,7 @@ const Feed = (props) => {
     });
   };
 
-  function objectiveURL() {
+  const objectiveURL = useCallback(() => {
     switch (selectedType) {
       case HELP_TYPE.REQUEST:
         return "&objective=request";
@@ -341,8 +341,9 @@ const Feed = (props) => {
       default:
         return "";
     }
-  }
-  function filterURL() {
+  }, [selectedType]);
+
+  const filterURL = useCallback(() => {
     const filterObj = {
       ...(selectedOptions["providers"] && {
         fromWhom: selectedOptions["providers"],
@@ -354,7 +355,7 @@ const Feed = (props) => {
     return Object.keys(filterObj).length === 0
       ? ""
       : `&filter=${encodeURIComponent(JSON.stringify(filterObj))}`;
-  }
+  }, [location, selectedOptions]);
 
   const loadPosts = useCallback(async () => {
     const limit = 5;
@@ -375,10 +376,10 @@ const Feed = (props) => {
       await postsDispatch({ type: ERROR_POSTS });
     }
     if (response.data && response.data.length) {
-      const loadedPosts = response.data.reduce(
-        (obj, item) => ((obj[item._id] = item), obj),
-        {},
-      );
+      const loadedPosts = response.data.reduce((obj, item) => {
+        obj[item._id] = item;
+        return obj;
+      }, {});
 
       await postsDispatch({
         type: SET_POSTS,

--- a/client/src/pages/NrMap.js
+++ b/client/src/pages/NrMap.js
@@ -49,8 +49,8 @@ const NrMap = () => {
   const googleMapRef = useRef();
   const googleMap = useRef();
 
-  const createGoogleMap = () => {
-    return new window.google.maps.Map(googleMapRef.current, {
+  const createGoogleMap = useCallback(() => {
+    new window.google.maps.Map(googleMapRef.current, {
       zoom: 13,
       center: {
         lat: coordinates.latitude,
@@ -58,9 +58,9 @@ const NrMap = () => {
       },
       disableDefaultUI: true,
     });
-  };
+  }, [coordinates.latitude, coordinates.longitude]);
 
-  const places = () => {
+  const places = useCallback(() => {
     new window.google.maps.places.PlacesService(googleMap.current).nearbySearch(
       {
         location: {
@@ -73,9 +73,9 @@ const NrMap = () => {
       (results, status) => {
         if (status !== "OK") return;
         setHospitals(results);
-      }
+      },
     );
-  };
+  }, [coordinates.latitude, coordinates.longitude]);
 
   const createMarker = useCallback(() => {
     const image = {
@@ -100,9 +100,9 @@ const NrMap = () => {
       position: { lat: coordinates.latitude, lng: coordinates.longitude },
       map: googleMap.current,
     });
-  });
+  }, [coordinates.latitude, coordinates.longitude, hospitals]);
 
-  const placeDetails = () => {
+  const placeDetails = useCallback(() => {
     hospitals.forEach((place) => {
       const request = {
         placeId: place.place_id,
@@ -124,10 +124,10 @@ const NrMap = () => {
               return [...detailedHospitals, req];
             });
           }
-        }
+        },
       );
     });
-  };
+  }, [hospitals]);
 
   useEffect(() => {
     const googleMapScript = document.createElement("script");
@@ -166,7 +166,7 @@ const NrMap = () => {
             latitude: "err-latitude",
             longitude: "err-longitude",
           });
-        }
+        },
       );
     }
   };


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
This PR finalizes the removal of all console warnings from the client, and closes PR #449 

Please guys let me know as I implemented what it seemed to work. I tested locally and it seems to work fine and nothing has been broken. 

### on /src/pages/Feed.js
- [x] The 'objectiveURL' function makes the dependencies of useCallback Hook (at line 390) change on every render. Move it inside the useCallback callback. Alternatively, wrap the 'objectiveURL' definition into its own useCallback() Hook  react-hooks/exhaustive-deps
- [x] The 'filterURL' function makes the dependencies of useCallback Hook (at line 390) change on every render. Move it inside the useCallback callback. Alternatively, wrap the 'filterURL' definition into its own useCallback() Hook        react-hooks/exhaustive-deps
- [x] Unexpected use of comma operator

### on /src/pages/NrMap.js
- [x] The 'createGoogleMap' function makes the dependencies of useEffect Hook (at line 144) change on every render. Move it inside the useEffect callback. Alternatively, wrap the 'createGoogleMap' definition into its own useCallback() Hook  react-hooks/exhaustive-deps
- [x] The 'places' function makes the dependencies of useEffect Hook (at line 144) change on every render. Move it inside the useEffect callback. Alternatively, wrap the 'places' definition into its own useCallback() Hook      react-hooks/exhaustive-deps
- [x] React Hook useCallback does nothing when called with only one argument. Did you forget to pass an array of dependencies. react-hooks/exhaustive-deps
- [x]  The 'placeDetails' function makes the dependencies of useEffect Hook (at line 151) change on every render. Move it inside the useEffect callback. Alternatively, wrap the 'placeDetails' definition into its own useCallback() Hook        react-hooks/exhaustive-deps