### PR TITLE
Add transition to NeedHelp and OfferHelp from Home

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5788,8 +5788,7 @@
     "csstype": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
-      "dev": true
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
     },
     "cyclist": {
       "version": "1.0.1",
@@ -6244,6 +6243,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
       }
     },
     "dom-serializer": {
@@ -15679,6 +15687,17 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/react-step-wizard/-/react-step-wizard-5.3.2.tgz",
       "integrity": "sha512-bnZyTm6RRbDGY3+0ajTVyv63ieKTE97V+BZv6ryhhQ12lUQK3X1jjghepA0qnBzUSN6FJ/d0yVfF8gCJX14SXg=="
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "react-tween-state": {
       "version": "0.1.5",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "react-step-wizard": "^5.3.2",
+    "react-transition-group": "^4.4.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "snyk": "^1.319.2",

--- a/client/src/components/StepWizard/StyledWizard.js
+++ b/client/src/components/StepWizard/StyledWizard.js
@@ -8,6 +8,19 @@ const StyledWizard = styled(StepWizard)`
   display: flex;
   flex-direction: column-reverse;
   align-self: flex-start;
+  transition: 0.5s; 
+  opacity: ${({ status }) => {
+    switch (status) {
+      case "entering":
+        return '0'
+      case "entered":
+        return '1'
+      case "exiting":
+        return '1'
+      case "exited":
+        return '0'
+    }
+  }};
   width: 100%;
   height: 100%;
   margin: 0 auto;

--- a/client/src/pages/NeedHelp.js
+++ b/client/src/pages/NeedHelp.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Transition } from 'react-transition-group';
 import { withRouter, Link } from "react-router-dom";
 import InputError from "components/Input/InputError";
 import LocationInput from "components/Input/LocationInput";
@@ -142,6 +143,12 @@ const Step3 = (props) => {
 
 const NeedHelp = withRouter((props) => {
   const [state, setState] = useState(INITIAL_STATE);
+  const [transition, setTransition] = useState(false);
+
+  useEffect(() => {
+    setTransition(!transition);
+  },[]);
+  
   const updateAnswers = (key, value) => {
     const { answers } = state;
     const updatedAnswers = { ...answers, [key]: value };
@@ -155,11 +162,15 @@ const NeedHelp = withRouter((props) => {
   };
   return (
     <WizardContainer className="wizard-container">
-      <StyledWizard isHashEnabled nav={<WizardNav />}>
-        <Step1 hashKey={"Step1"} update={updateAnswers} />
-        <Step2 hashKey={"Step2"} update={updateAnswers} />
-        <Step3 hashKey={"Step3"} update={updateAnswers} />
-      </StyledWizard>
+      <Transition in={transition} timeout={500}>
+        {status=> (
+          <StyledWizard isHashEnabled status={status} nav={<WizardNav/>}>
+            <Step1 hashKey={"Step1"} update={updateAnswers} />
+            <Step2 hashKey={"Step2"} update={updateAnswers} />
+            <Step3 hashKey={"Step3"} update={updateAnswers} />
+          </StyledWizard>
+        )}      
+      </Transition>
     </WizardContainer>
   );
 });

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Transition } from 'react-transition-group';
 import InputError from "components/Input/InputError";
 import { withRouter, Link } from "react-router-dom";
 import LocationInput from "components/Input/LocationInput";
@@ -167,6 +168,11 @@ const Step3 = (props) => {
 
 const OfferHelp = withRouter((props) => {
   const [state, setState] = useState(INITIAL_STATE);
+  const [transition, setTransition] = useState(false);
+
+  useEffect(() => {
+    setTransition(!transition);
+  },[]);
   const updateAnswers = (key, value) => {
     const { answers } = state;
     const updatedAnswers = { ...answers, [key]: value };
@@ -180,11 +186,15 @@ const OfferHelp = withRouter((props) => {
   };
   return (
     <WizardContainer className="wizard-container">
-      <StyledWizard isHashEnabled nav={<WizardNav />}>
-        <Step1 hashKey={"Step1"} update={updateAnswers} />
-        <Step2 hashKey={"Step2"} update={updateAnswers} />
-        <Step3 hashKey={"Step3"} update={updateAnswers} />
-      </StyledWizard>
+      <Transition in={transition} timeout={500}>
+        {status=> (
+          <StyledWizard isHashEnabled status={status} nav={<WizardNav />}>
+            <Step1 hashKey={"Step1"} update={updateAnswers} />
+            <Step2 hashKey={"Step2"} update={updateAnswers} />
+            <Step3 hashKey={"Step3"} update={updateAnswers} />
+          </StyledWizard>
+        )}
+      </Transition>
     </WizardContainer>
   );
 });


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Add transition when transitioning from `Home` page to `Need Help` and `Give Help` to be more smooth using the `react-transition-group` library.
_Please be concise and link any related issue(s):_
#689
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
