### PR TITLE
Adding redirect back button from post to feed page

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { Modal, Card, WhiteSpace } from "antd-mobile";
 import { Link, useParams } from "react-router-dom";
 import { Modal as WebModal } from "antd";
-
 import axios from "axios";
 
 // Local
@@ -17,7 +16,8 @@ import Heading from "components/Typography/Heading";
 import TextAvatar from "components/TextAvatar";
 import SubMenuButton from "components/Button/SubMenuButton";
 import { typeToTag } from "assets/data/formToPostMappings";
-
+import { StyledWizard } from "components/StepWizard";
+import WizardFormNav from "components/StepWizard/WizardFormNav";
 // Icons
 import SvgIcon from "../Icon/SvgIcon";
 import statusIndicator from "assets/icons/status-indicator.svg";
@@ -286,7 +286,7 @@ const Post = ({
           </>
         ) : (
           <>{renderSocialIcons}</>
-        )}
+        )}     
         <WebModal
           title="Confirm"
           visible={modalVisibility}
@@ -297,6 +297,9 @@ const Post = ({
         >
           <p>Are you sure you want to delete the post?</p>
         </WebModal>
+        {loadContent && 
+        <StyledWizard nav={<WizardFormNav />}></StyledWizard>
+        }   
       </PostCard>
     </>
   );

--- a/client/src/components/StepWizard/WizardFormNav.js
+++ b/client/src/components/StepWizard/WizardFormNav.js
@@ -1,0 +1,18 @@
+import React from "react";
+import backArrow from "assets/icons/back-arrow.svg";
+import { StyledWizardNav, BackButton, BackText } from 'components/StepWizard/WizardNav';
+import { Link } from "react-router-dom";
+import SvgIcon from "components/Icon/SvgIcon";
+
+const WizardFormNav = () => (
+  <StyledWizardNav>
+    <Link to={"/feed"}>
+      <BackButton>
+        <SvgIcon src={backArrow} title="Navigate to feed page" />
+        <BackText>Back</BackText>
+      </BackButton>
+    </Link>    
+  </StyledWizardNav>
+);
+
+export default WizardFormNav;

--- a/client/src/components/StepWizard/WizardNav.js
+++ b/client/src/components/StepWizard/WizardNav.js
@@ -13,7 +13,7 @@ const desktopBreakpoint = mq.tablet.narrow.maxWidth;
 
 const { royalBlue, white } = theme.colors;
 
-const StyledWizardNav = styled.div`
+export const StyledWizardNav = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -37,7 +37,7 @@ const StyledWizardNav = styled.div`
   }
 `;
 
-const BackButton = styled(LeftRightIconButton)`
+export const BackButton = styled(LeftRightIconButton)`
   align-items: center;
   background-color: transparent;
   color: ${royalBlue};
@@ -73,7 +73,7 @@ const BackButton = styled(LeftRightIconButton)`
   }
 `;
 
-const BackText = styled.span`
+export const BackText = styled.span`
   margin-left: 3rem;
 `;
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
#### Added a back button in the post details page to redirect back to the feeds page.
![FightPandemics (1)](https://user-images.githubusercontent.com/37174253/85361888-f2a0a400-b4d1-11ea-89b6-662aca95716f.gif)

_Please be concise and link any related issue(s):_

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
