### PR TITLE
handle auth error edge case

### DIFF
--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -2,8 +2,9 @@ import axios from "axios";
 import { 
   checkRememberCookie,
   clearRememberCookie,
-} from "utils/cookie"
+} from "utils/cookie";
 import {
+  AUTH_ERROR,
   AUTH_LOGOUT,
   SET_AUTH_LOADING,
   SET_USER,
@@ -18,9 +19,8 @@ export const initAuth =  () => {
     try {
       const { data: user } = await axios.get("/api/users/current");
       dispatch({ type: SET_USER, payload: { user } });
-    } catch (err) {
-      // TODO: do something with error -- user succesfully authenticated but can't find user (redirect to login?)
-      console.log(err);
+    } catch (error) {
+      dispatch({ error, type: AUTH_ERROR });
     } finally {
       dispatch({ type: SET_AUTH_LOADING, payload: false });
     }

--- a/client/src/constants/action-types.js
+++ b/client/src/constants/action-types.js
@@ -1,4 +1,5 @@
 export const AUTH_SUCCESS = "AUTH_LOGIN";
+export const AUTH_ERROR = "AUTH_ERROR";
 export const AUTH_LOGOUT = "AUTH_LOGOUT";
 export const SET_USER = "SET_USER";
 export const SET_AUTH_LOADING = "SET_AUTH_LOADING";

--- a/client/src/hooks/reducers/feedReducers.js
+++ b/client/src/hooks/reducers/feedReducers.js
@@ -17,6 +17,7 @@ export const postsState = {
   status: SET_POSTS,
   posts: [],
   page: 0,
+  error: null,
   filterType: "",
   isLoading: false,
   loadMore: true,
@@ -59,11 +60,18 @@ export const postsReducer = (state = postsState, action) => {
       return {
         ...state,
         status: SET_POSTS,
+        error: null,
         posts: action.posts,
         isLoading: false,
       };
     case ERROR_POSTS:
-      return { ...state, status: ERROR_POSTS, posts: [], isLoading: false };
+      return {
+        ...state,
+        status: ERROR_POSTS,
+        error: action.error,
+        posts: [],
+        isLoading: false,
+      };
     case NEXT_PAGE:
       return { ...state, page: state.page + 1 };
     case RESET_PAGE:

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -8,6 +8,7 @@ import { Layout, Menu } from "antd";
 
 // Local
 import CreatePost from "components/CreatePost/CreatePost";
+import ErrorAlert from "components/Alert/ErrorAlert";
 import filterOptions from "assets/data/filterOptions";
 import FeedWrapper from "components/Feed/FeedWrapper";
 import FilterBox from "components/Feed/FilterBox";
@@ -207,6 +208,7 @@ const Feed = (props) => {
 
   const filters = Object.values(filterOptions);
   const {
+    error: postsError,
     filterType,
     isLoading,
     loadMore,
@@ -378,7 +380,7 @@ const Feed = (props) => {
     try {
       response = await axios.get(endpoint);
     } catch (error) {
-      await postsDispatch({ type: ERROR_POSTS });
+      await postsDispatch({ error, type: ERROR_POSTS });
     }
 
     if (response && response.data && response.data.length) {
@@ -543,7 +545,7 @@ const Feed = (props) => {
               user={user}
               isAuthenticated={isAuthenticated}
             />
-            {status === ERROR_POSTS && <div>Something went wrong...</div>}
+            {status === ERROR_POSTS && <ErrorAlert message={postsError.message}/>}
             {isLoading ? <Loader /> : <></>}
             <SvgIcon
               src={creatPost}

--- a/client/src/reducers/sessionReducer.js
+++ b/client/src/reducers/sessionReducer.js
@@ -1,4 +1,5 @@
 import {
+  AUTH_ERROR,
   AUTH_LOGOUT,
   AUTH_SUCCESS,
   SET_AUTH_LOADING,
@@ -7,14 +8,21 @@ import {
 
 const initialState = {
   isAuthenticated: false,
+  authError: null,
   authLoading: false,
   email: null,
   emailVerified: false,
+  error: null,
   user: null,
 };
 
 function sessionReducer(state = initialState, action) {
   switch (action.type) {
+    case AUTH_ERROR:
+      return {
+        ...initialState,
+        authError: action.error,
+      };
     case AUTH_SUCCESS:
       return {
         ...state,

--- a/client/src/templates/RouteWithSubRoutes.js
+++ b/client/src/templates/RouteWithSubRoutes.js
@@ -8,6 +8,7 @@ import { connect } from "react-redux";
 
 export const HOME = "/";
 export const LOGIN = "/auth/login";
+export const LOGOUT = "/auth/logout";
 export const FEED = "/feed";
 export const VERIFY_EMAIL = "/auth/verify-email";
 export const CREATE_PROFILE = "/create-profile";
@@ -27,7 +28,15 @@ const getLayoutComponent = (layout) => {
 // handle "sub"-routes by passing them in a `routes`
 // prop to the component it renders.
 export const RouteWithSubRoutes = (route) => {
-  const { authLoading, emailVerified, isAuthenticated, path, props = {}, user } = route;
+  const {
+    authError,
+    authLoading,
+    emailVerified,
+    isAuthenticated,
+    path,
+    props = {},
+    user,
+  } = route;
   const { loggedInOnly, notLoggedInOnly, tabIndex, mobiletabs, forgotPassword } = props;
 
   return (
@@ -38,7 +47,10 @@ export const RouteWithSubRoutes = (route) => {
         let redirect;
 
         if (!authLoading) { // don't apply redirect if authLoading
-          if (loggedInOnly && !isAuthenticated) {
+          if (authError && location.pathname !== LOGOUT) {
+            // logout as means to handle auth error edge cases
+            redirect = LOGOUT;
+          } else if (loggedInOnly && !isAuthenticated) {
             redirect = LOGIN;
           } else if (notLoggedInOnly && isAuthenticated) {
             redirect = HOME;
@@ -84,6 +96,7 @@ export const RouteWithSubRoutes = (route) => {
 
 const mapDispatchToProps = {};
 const mapStateToProps = ({ session }) => ({
+  authError: session.authError,
   authLoading: session.authLoading,
   emailVerified: session.emailVerified,
   isAuthenticated: session.isAuthenticated,


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #796 

This was an edge case after initial sign-up where the Auth0 user is authenticated but Mongo user not created yet. If user closes the tab or navigates with the browser bar to let's say /feed they still have log-in cookies but there is no user so we get an error.

In first commit I added at least some error message instead of "Something went wrong" to make other issues that may occur easier to troubleshoot:

![image](https://user-images.githubusercontent.com/10546720/85462408-6cd53500-b573-11ea-915d-b7ce15c4e2b0.png)

2nd commit includes setting error state if an error is caught during `initAuth` and that error is checked in RouteWithSubRoute redirect logic - logging them out in such a case.

Open to alternate approaches.