### PR TITLE
add user hide address option

### DIFF
--- a/backend/lib/endpoints/schema/users.js
+++ b/backend/lib/endpoints/schema/users.js
@@ -16,6 +16,8 @@ const objectivesSchema = S.object()
   .prop("shareInformation", S.boolean().required().default(false))
   .prop("volunteer", S.boolean().required().default(false));
 
+const hideSchema = S.object().prop("address", S.boolean().default(false));
+
 const urlsSchema = S.object()
   .prop(
     "facebook",
@@ -49,6 +51,7 @@ const createUserSchema = {
   body: strictSchema()
     .prop("firstName", S.string().required())
     .prop("lastName", S.string().required())
+    .prop("hide", hideSchema)
     .prop("needs", needsSchema)
     .prop("objectives", objectivesSchema)
     .prop("url", urlsSchema)
@@ -65,6 +68,7 @@ const updateUserSchema = {
     .prop("about", S.string().maxLength(160))
     .prop("firstName", S.string())
     .prop("lastName", S.string())
+    .prop("hide", hideSchema)
     .prop("location", locationSchema)
     .prop("needs", needsSchema)
     .prop("objectives", objectivesSchema)

--- a/backend/lib/endpoints/users.js
+++ b/backend/lib/endpoints/users.js
@@ -16,7 +16,6 @@ async function routes(app) {
 
   app.get("/current", { preValidation: [app.authenticate] }, async (req) => {
     const { userId } = req;
-
     const [userErr, user] = await app.to(User.findById(userId));
     if (userErr) {
       req.log.error(userErr, "Failed retrieving user");
@@ -31,6 +30,7 @@ async function routes(app) {
       about,
       email,
       firstName,
+      hide,
       lastName,
       location,
       needs,
@@ -41,6 +41,7 @@ async function routes(app) {
       about,
       email,
       firstName,
+      hide,
       id,
       lastName,
       location,

--- a/backend/lib/models/IndividualUser.js
+++ b/backend/lib/models/IndividualUser.js
@@ -17,6 +17,9 @@ const individualUserSchema = new Schema(
       required: true,
       type: String,
     },
+    hide: {
+      address: { default: false, type: Boolean },
+    },
     lastName: {
       type: String,
     },

--- a/client/src/pages/CreateUserProfile.js
+++ b/client/src/pages/CreateUserProfile.js
@@ -332,8 +332,17 @@ const CreateProfile = ({ email, history }) => {
           {/*
             temporarily disabled until the fields are added to the API
           <CheckboxGroup description="I am traveling" />
-          <CheckboxGroup description="Don't show my address" />
           */}
+          <InputGroup>
+            <Controller
+              as={CheckboxGroup}
+              control={control}
+              defaultValue={false}
+              label="Don't show my address"
+              name="hide.address"
+              onChange={handleCheckboxChange}
+            />
+          </InputGroup>
           <InputGroup>
             <TextLabel
               color={theme.colors.royalBlue}

--- a/client/src/pages/EditAccount.js
+++ b/client/src/pages/EditAccount.js
@@ -76,8 +76,13 @@ function EditAccount() {
     mode: "change",
   });
   const { error, loading, user } = userProfileState;
-  const { firstName = "", lastName = "", objectives = {}, needs = {} } =
-    user || {};
+  const {
+    firstName = "",
+    hide = {},
+    lastName = "",
+    needs = {},
+    objectives = {},
+  } = user || {};
 
   const handleLocationChange = (location) => {
     setLocation(location);
@@ -188,6 +193,18 @@ function EditAccount() {
                 onLocationChange={handleLocationChange}
               />
             </InputWrapper>
+            <CheckBoxWrapper>
+              <Controller
+                as={Checkbox}
+                defaultValue={hide.address}
+                name="hide.address"
+                control={control}
+                onChange={([event]) => event.target.checked}
+                valueName="checked"
+              >
+                <Label inputColor="#000000">Don't show my address</Label>
+              </Controller>
+            </CheckBoxWrapper>
             <Label>I want to</Label>
             <HelpWrapper>
               {Object.entries(OBJECTIVES).map(([key, label]) => (


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #806. Required for #805 . Enables option to hide address for public user profile.

Create user profile:
![image](https://user-images.githubusercontent.com/10546720/85580571-dbfd6880-b609-11ea-90c4-4515578b7306.png)

Edit user account information:

![image](https://user-images.githubusercontent.com/10546720/85580745-ffc0ae80-b609-11ea-8861-dff98aedc8b5.png)


@robinv85 @Naraujo13 @joaofnds  for the data model I added a `hide` object as well will probably add for email as well soon-ish. This could be called `hides` or `privacy` not sure the best choice. Privacy settings and get quite complex so if we go down the path of something like LinkedIn/Facebook this will require migration later I'm sure. 

Also @robinv85 I removed the 'required' property as we'll have a default `false` due to earlier suggestion with respect to default+required being an anti-pattern. Not sure if there's a good reason to have both in mongoose SchemaType however (I don't think so...)

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [ ] I have checked that no one else is working on similar changes.
- [ ] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [ ] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [ ] This branch is rebased/merged with the **latest master**.
- [ ] There are no merge conflicts.
- [ ] There are no console warnings and errors.
- [ ] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
