### PR TITLE
Fixing Back button position and visibility in Post page 

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -16,8 +16,8 @@ import Heading from "components/Typography/Heading";
 import TextAvatar from "components/TextAvatar";
 import SubMenuButton from "components/Button/SubMenuButton";
 import { typeToTag } from "assets/data/formToPostMappings";
-import { StyledWizard } from "components/StepWizard";
-import WizardFormNav from "components/StepWizard/WizardFormNav"
+import { StyledButtonWizard } from "components/StepWizard/WizardFormNav";
+import WizardFormNav from "components/StepWizard/WizardFormNav";
 // Icons
 import SvgIcon from "../Icon/SvgIcon";
 import statusIndicator from "assets/icons/status-indicator.svg";
@@ -298,7 +298,7 @@ const Post = ({
           <p>Are you sure you want to delete the post?</p>
         </WebModal>
         {postId && 
-        <StyledWizard nav={<WizardFormNav />}></StyledWizard>
+        <StyledButtonWizard nav={<WizardFormNav />}></StyledButtonWizard>
         }   
       </PostCard>
     </>

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -17,7 +17,7 @@ import TextAvatar from "components/TextAvatar";
 import SubMenuButton from "components/Button/SubMenuButton";
 import { typeToTag } from "assets/data/formToPostMappings";
 import { StyledWizard } from "components/StepWizard";
-import WizardFormNav from "components/StepWizard/WizardFormNav";
+import WizardFormNav from "components/StepWizard/WizardFormNav"
 // Icons
 import SvgIcon from "../Icon/SvgIcon";
 import statusIndicator from "assets/icons/status-indicator.svg";
@@ -297,7 +297,7 @@ const Post = ({
         >
           <p>Are you sure you want to delete the post?</p>
         </WebModal>
-        {loadContent && 
+        {postId && 
         <StyledWizard nav={<WizardFormNav />}></StyledWizard>
         }   
       </PostCard>

--- a/client/src/components/StepWizard/WizardFormNav.js
+++ b/client/src/components/StepWizard/WizardFormNav.js
@@ -1,16 +1,44 @@
 import React from "react";
+import styled from "styled-components";
 import backArrow from "assets/icons/back-arrow.svg";
 import { StyledWizardNav, BackButton, BackText } from 'components/StepWizard/WizardNav';
 import { Link } from "react-router-dom";
 import SvgIcon from "components/Icon/SvgIcon";
+import StepWizard from "react-step-wizard";
+import { mq } from "constants/theme";
+const desktopBreakpoint = mq.tablet.narrow.maxWidth;
 
-const WizardFormNav = () => (
+export const StyledButtonWizard = styled(StepWizard)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 12rem;
+  margin: 0 auto 1rem;
+  width: 35rem;
+  max-width: 100%;
+
+  & + div {
+    display: flex;
+    flex-flow: row wrap;
+    max-height: calc(100% - 8rem); /* align-items: stretch; */
+
+    & > div {
+      min-height: 100%;
+    }
+  }
+
+  @media screen and (min-width: ${desktopBreakpoint}) {
+    width: 40rem;
+  }
+`;
+
+export const WizardFormNav = () => (
   <StyledWizardNav>
     <Link to={"/feed"}>
-      <BackButton>
-        <SvgIcon src={backArrow} title="Navigate to feed page" />
-        <BackText>Back</BackText>
-      </BackButton>
+        <BackButton>
+          <SvgIcon src={backArrow} title="Navigate to feed page" />
+          <BackText>Back</BackText>
+        </BackButton>
     </Link>    
   </StyledWizardNav>
 );

--- a/client/src/components/StepWizard/WizardFormNav.js
+++ b/client/src/components/StepWizard/WizardFormNav.js
@@ -35,10 +35,10 @@ export const StyledButtonWizard = styled(StepWizard)`
 export const WizardFormNav = () => (
   <StyledWizardNav>
     <Link to={"/feed"}>
-        <BackButton>
-          <SvgIcon src={backArrow} title="Navigate to feed page" />
-          <BackText>Back</BackText>
-        </BackButton>
+      <BackButton>
+        <SvgIcon src={backArrow} title="Navigate to feed page" />
+        <BackText>Back</BackText>
+      </BackButton>
     </Link>    
   </StyledWizardNav>
 );

--- a/client/src/components/StepWizard/WizardFormNav.js
+++ b/client/src/components/StepWizard/WizardFormNav.js
@@ -32,7 +32,7 @@ export const StyledButtonWizard = styled(StepWizard)`
   }
 `;
 
-export const WizardFormNav = () => (
+const WizardFormNav = () => (
   <StyledWizardNav>
     <Link to={"/feed"}>
       <BackButton>


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Centering the position of `Back` button in post page, and maintaining the visibility of the button when the post is collapsed : 
<img width="810" alt="Screen Shot 2020-06-24 at 11 04 23 PM" src="https://user-images.githubusercontent.com/37174253/85664829-907da580-b66f-11ea-8ccc-8193ec806635.png">

_Please be concise and link any related issue(s):_
#804 
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
