### PR TITLE
Fix showing user's post activity on profile page

### DIFF
--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -115,13 +115,13 @@ const Profile = () => {
     (async function fetchPosts() {
       postsDispatch({ type: FETCH_POSTS });
       try {
-        const res = await axios.get(
-          `/api/posts?limit=5&skip0=&userId=${userId}`,
-        );
-        postsDispatch({
-          type: SET_POSTS,
-          user: res.data,
-        });
+        if (userId) {
+          const res = await axios.get(`/api/posts?limit=5&authorId=${userId}`);
+          postsDispatch({
+            type: SET_POSTS,
+            posts: res.data,
+          });
+        }
       } catch (err) {
         const message = err.response?.data?.message || err.message;
         postsDispatch({


### PR DESCRIPTION
Fixes issue mentioned in and closes #824 

Most of the functionality was in place. The request to fetch posts was not being executed properly, and the posts were not being set correctly. 




