### PR TITLE
Fix/Proposal - Profile page create post functionality

### DIFF
--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -52,13 +52,13 @@ const Step1 = () => {
 const Step2 = ({ user }) => {
   const createPostContext = useContext(CreatePostContext);
   const { setForm, currentStep, setCurrentStep } = createPostContext;
- 
+
   return (
     currentStep === 2 && (
       <>
         <TitleStep>Posting as an Organisation</TitleStep>
         <BackButton src={back} onClick={() => setCurrentStep(1)} />
-        {user.organizations.map((item) => {
+        {user.organizations?.map((item) => {
           return (
             <OptionButton
               key={item.id}
@@ -147,7 +147,7 @@ const CreatePost = (props) => {
     >
       <Wrapper {...props}>
         <Step1 />
-        <Step2 user={props.user}/>
+        <Step2 user={props.user} />
         <Step4 />
       </Wrapper>
       <Step3 {...props} />

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -200,7 +200,11 @@ const Profile = () => {
         </SectionHeader>
         <FeedWrapper>
           <Activity filteredPosts={postsState.posts} />
-          <CreatePost onCancel={() => setModal(false)} visible={modal} />
+          <CreatePost
+            onCancel={() => setModal(false)}
+            visible={modal}
+            user={user}
+          />
         </FeedWrapper>
       </div>
       <CustomDrawer


### PR DESCRIPTION
Fixes bug introduced by #849 (I missed this in review and merged it to master)

Prop `user` for `CreatePost` was missing for the profile page.

Side note: 
I looked to see if we had designs laid out for the Profile page in Figma, and there wasn't anything to go off of. 

Does it make sense to be able to create a post from your profile page?

I was thinking it may be better to just refactor the button on the profile page to redirect you to the feed and open up the create post modal there. Thoughts?
