### PR TITLE
refetch user on org add/update

### DIFF
--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -27,6 +27,17 @@ export const initAuth =  () => {
   };
 };
 
+export const refetchUser =  () => {
+  return async (dispatch) => {
+    try {
+      const { data: user } = await axios.get("/api/users/current");
+      dispatch({ type: SET_USER, payload: { user } });
+    } catch (error) {
+      dispatch({ error, type: AUTH_ERROR });
+    }
+  };
+};
+
 export const authLogout = () => {
   return (dispatch) => {
     clearRememberCookie();

--- a/client/src/pages/EditOrganizationAccount.js
+++ b/client/src/pages/EditOrganizationAccount.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext, useState } from "react";
 import styled from "styled-components";
 import { useForm, Controller } from "react-hook-form";
+import { connect } from "react-redux";
 import Checkbox from "components/Input/Checkbox";
 import { WhiteSpace } from "antd-mobile";
 import FormInput from "components/Input/FormInput";
@@ -44,6 +45,7 @@ import Marker from "../assets/create-profile-images/location-marker.svg";
 import LocationInput from "../components/Input/LocationInput";
 import ProfilePic from "components/Picture/ProfilePic";
 import { getInitials } from "utils/userInfo";
+import { refetchUser } from "actions/authActions";
 
 const errorStyles = {
   color: "#FF5656",
@@ -64,7 +66,7 @@ const NEEDS = {
   other: "Other",
 };
 
-function EditOrganizationAccount(props) {
+function EditOrganizationAccount({ refetchUser }) {
   // TODO: integrate location w proper react-hook-forms use
   const organizationId = window.location.pathname.split("/")[2];
   const [location, setLocation] = useState({});
@@ -104,6 +106,7 @@ function EditOrganizationAccount(props) {
         formData,
       );
       orgProfileDispatch(updateOrganizationSuccess(res.data));
+      refetchUser();
     } catch (err) {
       const message = err.response?.data?.message || err.message;
       orgProfileDispatch(
@@ -345,4 +348,13 @@ function EditOrganizationAccount(props) {
   );
 }
 
-export default withOrganizationContext(EditOrganizationAccount);
+const mapDispatchToProps = {
+  refetchUser,
+};
+
+// mixing context & redux is awkward here
+// TODO: implement consistent approach to state management
+export default connect(
+  null,
+  mapDispatchToProps
+)(withOrganizationContext(EditOrganizationAccount));

--- a/client/src/pages/OrgProfileComplete.js
+++ b/client/src/pages/OrgProfileComplete.js
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { withRouter } from "react-router-dom";
+import { connect } from "react-redux";
 import { WhiteSpace } from "antd-mobile";
 import { theme, mq } from "../constants/theme";
 import smiley from "../assets/icons/smiley.svg";
 import { Link } from "react-router-dom";
+import { refetchUser } from "actions/authActions";
 
 const Container = styled.div`
   width: 100%;
@@ -60,7 +62,11 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const OrgProfileComplete = (props) => {
+const OrgProfileComplete = ({ history, refetchUser }) => {
+  useEffect(() => {
+    refetchUser();
+  // will only run once (on mount) to update navbar org list
+  }, [refetchUser]);
   return (
     <Container>
       <WhiteSpace />
@@ -75,7 +81,7 @@ const OrgProfileComplete = (props) => {
       <WhiteSpace />
       <WhiteSpace />
       <ButtonsContainer>
-        <StyledLink to={`/organization/${props.history.location.state.orgId}`}>
+        <StyledLink to={`/organization/${history.location.state.orgId}`}>
           View my profile
         </StyledLink>
         <WhiteSpace />
@@ -86,4 +92,11 @@ const OrgProfileComplete = (props) => {
   );
 };
 
-export default withRouter(OrgProfileComplete);
+const mapDispatchToProps = {
+  refetchUser,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(withRouter(OrgProfileComplete));


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #864 

We are re-fetching user to update redux session store when an organization is added or updated (we don't have delete functionality yet).

@robinv85 you are right it does seem awkward mixing context & redux in `EditOrganizationAccount.js` but I see no other way without refactoring towards full use of redux.

Open to other ideas however. 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
