### PR TITLE
add safe navigation to user?.organizations?.

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -108,15 +108,14 @@ export default ({ authLoading, onMenuClick, isAuthenticated, user }) => {
         <Link to="/create-organization-profile">Add Organisation</Link>
       </Menu.Item>
       <Menu.Divider />
-      {user
-        ? user.organizations.map((organization) => (
-            <Menu.Item>
-              <Link to={`/organization/${organization._id}`}>
-                {organization.name}
-              </Link>
-            </Menu.Item>
-          ))
-        : null}
+      {user?.organizations?.map((organization) => (
+        <Menu.Item>
+          <Link to={`/organization/${organization._id}`}>
+            {organization.name}
+          </Link>
+        </Menu.Item>
+        ))
+      }
 
       <Menu.Divider />
       <Menu.Item>


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

We get this error after profile creation. I'm trying to figure out the best way for the B/E to always send the same data regardless of login/signup/create/etc but until then if we use the full safe operator like `user?.organizations?.` that is best. @MohamedEl1 do the same when adding the mobile.

Resolves #870 

```
TypeError: "o.organizations is undefined"
    mc Header.js:110
    React 6
    unstable_runWithPriority scheduler.production.min.js:19
    React 6
    unlisten Router.js:33
    r history.js:155
    notifyListeners history.js:173
    notifyListeners history.js:172
    _ history.js:288
    push history.js:369
    confirmTransitionTo history.js:145
    push history.js:350
    e CreateUserProfile.js:217
    s runtime.js:45
    _invoke runtime.js:274
    t runtime.js:97
    Babel 2


<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
