### PR TITLE
Add Terraform Fargate task module to main repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ locals {
 }
 
 module "main" {
-  source     = "github.com/FightPandemics/tf-fargate-task//module"
+  source     = "./terraform-task-module"
   aws_region = var.aws_region
   image_tag  = var.env_name
   fp_context = var.fp_context

--- a/terraform-task-module/alb-listener-rule.tf
+++ b/terraform-task-module/alb-listener-rule.tf
@@ -1,0 +1,23 @@
+resource "aws_alb_target_group" "app" {
+  name        = replace(substr(var.subdomain, 0 , 32), "/-$/" , "" )
+  port        = var.client_port
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.main.id
+  target_type = "ip"
+  health_check {
+    enabled = true
+    matcher = "200,401,404"
+  }
+}
+
+resource "aws_alb_listener_rule" "main" {
+  listener_arn = data.aws_alb_listener.main.arn
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.app.arn
+  }
+  condition {
+    field = "host-header"
+    values = [var.fp_context == "production" ? "fightpandemics.com" : "${var.subdomain}.*"]
+  }
+}

--- a/terraform-task-module/locals.tf
+++ b/terraform-task-module/locals.tf
@@ -1,0 +1,39 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ecs_cluster" "main" {
+  cluster_name = "${var.fp_context}-cluster"
+}
+
+data "aws_security_group" "default" {
+  name   = "default"
+  vpc_id = data.aws_vpc.main.id
+}
+
+data "aws_alb" "main" {
+  name = "${var.fp_context}-alb"
+}
+
+data "aws_alb_listener" "main" {
+  load_balancer_arn = data.aws_alb.main.arn
+  port              = 443
+}
+
+data "aws_vpc" "main" {
+  filter {
+    name   = "tag:Name"
+    values = [var.fp_context]
+  }
+}
+
+data "aws_subnet_ids" "public" {
+  vpc_id = data.aws_vpc.main.id
+  tags = {
+    Tier = "public"
+  }
+}
+
+data "aws_iam_role" "ecs_execution_role" {
+  name = "ecs-task-execution"
+}

--- a/terraform-task-module/logging.tf
+++ b/terraform-task-module/logging.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "backend" {
+  name              = "/ecs/${var.subdomain}-backend"
+  retention_in_days = 1
+}
+resource "aws_cloudwatch_log_group" "client" {
+  name              = "/ecs/${var.subdomain}-client"
+  retention_in_days = 1
+}

--- a/terraform-task-module/security-group.tf
+++ b/terraform-task-module/security-group.tf
@@ -1,0 +1,19 @@
+resource "aws_security_group" "app" {
+  name        = var.subdomain
+  description = "allow inbound access from the vpc only"
+  vpc_id      = data.aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.client_port
+    to_port     = var.client_port
+    cidr_blocks = [data.aws_vpc.main.cidr_block]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform-task-module/service.tf
+++ b/terraform-task-module/service.tf
@@ -1,0 +1,21 @@
+resource "aws_ecs_service" "app" {
+  name            = var.subdomain
+  task_definition = aws_ecs_task_definition.app.arn
+  cluster         = data.aws_ecs_cluster.main.id
+
+  desired_count = var.fp_context == "production" ? 2 : 1
+  launch_type   = "FARGATE"
+  network_configuration {
+    subnets          = data.aws_subnet_ids.public.ids
+    security_groups  = [aws_security_group.app.id, data.aws_security_group.default.id]
+    assign_public_ip = true
+  }
+  load_balancer {
+    target_group_arn = aws_alb_target_group.app.arn
+    container_name   = "client"
+    container_port   = var.client_port
+  }
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}

--- a/terraform-task-module/task-definition.tf
+++ b/terraform-task-module/task-definition.tf
@@ -1,0 +1,58 @@
+resource "aws_ecs_task_definition" "app" {
+  family                   = var.subdomain
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 4096
+  execution_role_arn       = data.aws_iam_role.ecs_execution_role.arn
+  task_role_arn            = data.aws_iam_role.ecs_execution_role.arn
+  container_definitions    = <<DEFINITION
+  [
+    {
+      "cpu": 512,
+      "name": "backend",
+      "essential": true,
+      "image": "fightpandemics/backend:${var.image_tag}",
+      "memory": 4096,
+      "memoryReservation": 1024,
+      "portMappings": [
+        {
+          "containerPort": ${var.backend_port},
+          "hostPort": ${var.backend_port}
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-region": "${var.aws_region}",
+          "awslogs-group": "/ecs/${var.subdomain}-backend",
+          "awslogs-stream-prefix": "${var.fp_context}"
+        }
+      },
+      "environment": ${jsonencode(var.backend_env_variables)}
+    },
+    {
+      "cpu": 256,
+      "name": "client",
+      "essential": true,
+      "image": "fightpandemics/client:${var.image_tag}",
+      "memory": 4096,
+      "memoryReservation": 1024,
+      "portMappings": [
+        {
+          "containerPort": ${var.client_port},
+          "hostPort": ${var.client_port}
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-region": "${var.aws_region}",
+          "awslogs-group": "/ecs/${var.subdomain}-client",
+          "awslogs-stream-prefix": "${var.fp_context}"
+        }
+      }
+    }
+  ]
+DEFINITION
+}

--- a/terraform-task-module/variables.tf
+++ b/terraform-task-module/variables.tf
@@ -1,0 +1,26 @@
+variable "aws_region" {
+  type = string
+  default = "us-east-1"
+}
+variable "fp_context" {
+  type = string
+}
+variable "image_tag" {}
+variable "subdomain" {
+  type = string
+}
+variable "backend_env_variables" {
+  default = []
+  type = list(object({
+    name: string
+    value: string
+  }))
+}
+variable "backend_port" {
+  type = number
+  default = 8000
+}
+variable "client_port" {
+  type = number
+  default = 80
+}


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

This Terraform code was in a separate repo, but it makes deployments brittle since all branches point to the master branch of the other repo. So any change to that repo will reflect across all branches in this repo when it pulls in the module in `main.tf`.

Note that nothing has changed in the code. I just copied and pasted the module folder from the [tf-fargate-task](https://github.com/FightPandemics/tf-fargate-task) repo to this repo. I also had to update `main.tf` to point to the new module folder in this repo.

Resolves #883 
