### PR TITLE
Fix key errors and creating post from Organization page

### DIFF
--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -62,7 +62,7 @@ const Step2 = ({ user }) => {
         {user.organizations?.map((item) => {
           return (
             <OptionButton
-              key={item.id}
+              key={item._id}
               onClick={() => {
                 setForm({ organization: item });
                 setCurrentStep(3);

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -109,13 +109,12 @@ export default ({ authLoading, onMenuClick, isAuthenticated, user }) => {
       </Menu.Item>
       <Menu.Divider />
       {user?.organizations?.map((organization) => (
-        <Menu.Item>
+        <Menu.Item key={organization._id}>
           <Link to={`/organization/${organization._id}`}>
             {organization.name}
           </Link>
         </Menu.Item>
-        ))
-      }
+      ))}
 
       <Menu.Divider />
       <Menu.Item>


### PR DESCRIPTION
Fixes and closes issue #867 
Partially addresses #865 key warning.

This fixes the blank screen error when trying to create a post from an organization profile page. Also fixes key errors in the console from lists in `Header` and `CreatePost`. 
