### PR TITLE
Add Datadog Fargate task monitoring

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ variable "fp_context" {
 }
 
 variable "commit_hash" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -53,6 +53,11 @@ data "aws_ssm_parameter" "logger_host" {
 
 data "aws_ssm_parameter" "logger_port" {
   name = "/fp/logger/port"
+}
+
+data "aws_ssm_parameter" "datadog_api_key" {
+  count = var.fp_context == "production" ? 1 : 0
+  name  = "/fp/datadog/key"
 }
 
 locals {
@@ -136,5 +141,19 @@ module "main" {
       name  = "LOGGER_PORT",
       value = data.aws_ssm_parameter.logger_port.value
     },
+  ]
+  datadog_env_variables = [
+    {
+      name  = "DD_API_KEY",
+      value = var.fp_context == "production" ? data.aws_ssm_parameter.datadog_api_key[0].value : ""
+    },
+    {
+      name  = "DD_SITE",
+      value = "datadoghq.eu"
+    },
+    {
+      name  = "ECS_FARGATE",
+      value = "true"
+    }
   ]
 }

--- a/terraform-task-module/alb-listener-rule.tf
+++ b/terraform-task-module/alb-listener-rule.tf
@@ -1,5 +1,5 @@
 resource "aws_alb_target_group" "app" {
-  name        = replace(substr(var.subdomain, 0 , 32), "/-$/" , "" )
+  name        = replace(substr(var.subdomain, 0, 32), "/-$/", "")
   port        = var.client_port
   protocol    = "HTTP"
   vpc_id      = data.aws_vpc.main.id
@@ -17,7 +17,7 @@ resource "aws_alb_listener_rule" "main" {
     target_group_arn = aws_alb_target_group.app.arn
   }
   condition {
-    field = "host-header"
+    field  = "host-header"
     values = [var.fp_context == "production" ? "fightpandemics.com" : "${var.subdomain}.*"]
   }
 }

--- a/terraform-task-module/logging.tf
+++ b/terraform-task-module/logging.tf
@@ -6,3 +6,8 @@ resource "aws_cloudwatch_log_group" "client" {
   name              = "/ecs/${var.subdomain}-client"
   retention_in_days = 1
 }
+resource "aws_cloudwatch_log_group" "datadog-agent" {
+  count             = var.fp_context == "production" ? 1 : 0
+  name              = "/ecs/${var.subdomain}-datadog"
+  retention_in_days = 1
+}

--- a/terraform-task-module/task-definition.tf
+++ b/terraform-task-module/task-definition.tf
@@ -1,3 +1,51 @@
+locals {
+  backend_container_definition = {
+    cpu               = 512
+    name              = "backend"
+    essential         = true
+    image             = "fightpandemics/backend:${var.image_tag}"
+    memory            = 4096
+    memoryReservation = 1024
+    portMappings = [
+      {
+        containerPort = var.backend_port
+        hostPort      = var.backend_port
+      }
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-region        = var.aws_region
+        awslogs-group         = "/ecs/${var.subdomain}-backend"
+        awslogs-stream-prefix = var.fp_context
+      }
+    }
+    environment = var.backend_env_variables
+  }
+  client_container_definition = {
+    cpu               = 256
+    name              = "client"
+    essential         = true
+    image             = "fightpandemics/client:${var.image_tag}"
+    memory            = 4096
+    memoryReservation = 1024
+    portMappings = [
+      {
+        containerPort = var.client_port
+        hostPort      = var.client_port
+      }
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-region        = var.aws_region
+        awslogs-group         = "/ecs/${var.subdomain}-client"
+        awslogs-stream-prefix = var.fp_context
+      }
+    }
+  }
+}
+
 resource "aws_ecs_task_definition" "app" {
   family                   = var.subdomain
   network_mode             = "awsvpc"
@@ -6,53 +54,8 @@ resource "aws_ecs_task_definition" "app" {
   memory                   = 4096
   execution_role_arn       = data.aws_iam_role.ecs_execution_role.arn
   task_role_arn            = data.aws_iam_role.ecs_execution_role.arn
-  container_definitions    = <<DEFINITION
-  [
-    {
-      "cpu": 512,
-      "name": "backend",
-      "essential": true,
-      "image": "fightpandemics/backend:${var.image_tag}",
-      "memory": 4096,
-      "memoryReservation": 1024,
-      "portMappings": [
-        {
-          "containerPort": ${var.backend_port},
-          "hostPort": ${var.backend_port}
-        }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-region": "${var.aws_region}",
-          "awslogs-group": "/ecs/${var.subdomain}-backend",
-          "awslogs-stream-prefix": "${var.fp_context}"
-        }
-      },
-      "environment": ${jsonencode(var.backend_env_variables)}
-    },
-    {
-      "cpu": 256,
-      "name": "client",
-      "essential": true,
-      "image": "fightpandemics/client:${var.image_tag}",
-      "memory": 4096,
-      "memoryReservation": 1024,
-      "portMappings": [
-        {
-          "containerPort": ${var.client_port},
-          "hostPort": ${var.client_port}
-        }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-region": "${var.aws_region}",
-          "awslogs-group": "/ecs/${var.subdomain}-client",
-          "awslogs-stream-prefix": "${var.fp_context}"
-        }
-      }
-    }
-  ]
-DEFINITION
+  container_definitions    = jsonencode([
+    local.backend_container_definition,
+    local.client_container_definition
+  ])
 }

--- a/terraform-task-module/variables.tf
+++ b/terraform-task-module/variables.tf
@@ -16,6 +16,13 @@ variable "backend_env_variables" {
     value: string
   }))
 }
+variable "datadog_env_variables" {
+  default = []
+  type = list(object({
+    name: string
+    value: string
+  }))
+}
 variable "backend_port" {
   type = number
   default = 8000

--- a/terraform-task-module/variables.tf
+++ b/terraform-task-module/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_region" {
-  type = string
+  type    = string
   default = "us-east-1"
 }
 variable "fp_context" {
@@ -12,22 +12,22 @@ variable "subdomain" {
 variable "backend_env_variables" {
   default = []
   type = list(object({
-    name: string
-    value: string
+    name : string
+    value : string
   }))
 }
 variable "datadog_env_variables" {
   default = []
   type = list(object({
-    name: string
-    value: string
+    name : string
+    value : string
   }))
 }
 variable "backend_port" {
-  type = number
+  type    = number
   default = 8000
 }
 variable "client_port" {
-  type = number
+  type    = number
   default = 80
 }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Adds a Datadog container to the Fargate task definition which will monitor the performance of both the client and backend containers. This container is only added in production; the staging and review environments do not require application performance monitoring.

In order to conditionally add the Datadog container to the task definition, I had to refactor the code in `task-definition.tf` to define each container as a Terraform map, rather than JSON. Then it was simply a matter of checking the value of `fp_context` and including the Datadog definition only if `fp_context` is `production`.

I also created a Slack channel called `#performance-monitoring`, where Datadog alerts will be sent to.

Resolves #762 
