### PR TITLE
Add liked and likes count at GET /posts/:postId

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -352,7 +352,7 @@ async function routes(app) {
       return {
         comments,
         numComments,
-        projectedPost,
+        post: projectedPost,
       };
     },
   );

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -285,6 +285,7 @@ async function routes(app) {
       schema: getPostByIdSchema,
     },
     async (req) => {
+      const { userId } = req;
       const { postId } = req.params;
       const [postErr, post] = await app.to(Post.findById(postId));
       if (postErr) {
@@ -341,10 +342,17 @@ async function routes(app) {
           numComments = commentQuery[0].comments;
         }
       }
+
+      const projectedPost = {
+        ...post.toObject(),
+        liked: post.likes.includes(mongoose.Types.ObjectId(userId)),
+        likesCount: post.likes.length,
+      };
+
       return {
         comments,
         numComments,
-        post,
+        projectedPost,
       };
     },
   );


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Add the following fields to the response of the `GET /posts/:postId` endpoint:
- `liked`: boolean value with whether the user current logged user (if present) already liked this post or not
- `likesCount`: number of likes currently at this post

Both fields were already returned at `GET /posts/`, so this just adds the same structure to the single post response.

Closes #843
