### PR TITLE
Uniform checkbox styles and fix off-center text in offering help wizard

### DIFF
--- a/client/src/components/StepWizard/WizardCheckboxItem.js
+++ b/client/src/components/StepWizard/WizardCheckboxItem.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import React from "react";
-import { Checkbox } from "antd-mobile";
 import { theme, mq } from "constants/theme";
+import StyledCheckbox from "components/Input/Checkbox";
 
 const { white, lightGray, royalBlue, black } = theme.colors;
 
@@ -70,7 +70,7 @@ export const WizardCheckboxItem = ({ text, checked, onChange, ...props }) => {
       className={checked && "selected"}
       {...props}
     >
-      <Checkbox checked={checked} />
+      <StyledCheckbox checked={checked} />
       <span className="text">{text}</span>
     </CheckboxItemStyles>
   );

--- a/client/src/components/StepWizard/WizardCheckboxItem.js
+++ b/client/src/components/StepWizard/WizardCheckboxItem.js
@@ -59,7 +59,6 @@ const CheckboxItemStyles = styled.div`
   @media screen and (min-width: ${mq.tablet.wide.minWidth}) {
     border: 0.1rem solid ${lightGray};
     border-radius: 5px;
-    height: 6rem;
   }
 `;
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
The checkbox styles in [Step 1/1 of offering help wizard](https://staging.fightpandemics.work/offer-help) have been changed to match the ones used in [create an organization profile](https://staging.fightpandemics.work/create-organization-profile) (clicking this link doesn't redirect properly to the create org profile page though) by using the styled antd checkbox instead of antd-mobile
![image](https://user-images.githubusercontent.com/18688793/86156251-a659f300-bad3-11ea-8d3f-ebe4f105867c.png)

Before:
![image](https://user-images.githubusercontent.com/18688793/86153875-47df4580-bad0-11ea-8f08-6dd350804348.png)

After:
![image](https://user-images.githubusercontent.com/18688793/86153896-4f065380-bad0-11ea-9947-18703d3d858e.png)

I also fixed the off-center text - it was because of a seemingly arbitrary height constraint, but if that was intended, let me know and I can revert it

_Please be concise and link any related issue(s):_
Resolves #822 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [ ] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [ ] This branch is rebased/merged with the **latest master**.
- [ ] There are no merge conflicts.
- [ ] There are no console warnings and errors.
- [ ] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
