### PR TITLE
Fixed comments age reactivity issue

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -1,6 +1,8 @@
 const mongoose = require("mongoose");
 const moment = require("moment");
 
+const { translateISOtoRelativeTime } = require("../utils");
+
 const {
   createCommentSchema,
   getCommentsSchema,
@@ -538,6 +540,11 @@ async function routes(app) {
           },
         ]),
       );
+      // Set 'timeElapsed' property on every comment.
+      comments.forEach(comment => {
+        comment.timeElapsed = translateISOtoRelativeTime(comment.createdAt);
+      })
+
       if (commentErr) {
         req.log.error(commentErr, "Failed retrieving comments");
         throw app.httpErrors.internalServerError();

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -538,13 +538,13 @@ async function routes(app) {
           {
             $limit: parseInt(limit) || COMMENT_PAGE_SIZE,
           },
-        ]),
+        ]).then(comments => {
+          comments.forEach(comment => {
+            comment.timeElapsed = translateISOtoRelativeTime(comment.createdAt);
+           })
+          return comments;
+        })
       );
-      // Set 'timeElapsed' property on every comment.
-      comments.forEach(comment => {
-        comment.timeElapsed = translateISOtoRelativeTime(comment.createdAt);
-      })
-
       if (commentErr) {
         req.log.error(commentErr, "Failed retrieving comments");
         throw app.httpErrors.internalServerError();

--- a/backend/lib/models/Comment.js
+++ b/backend/lib/models/Comment.js
@@ -16,7 +16,6 @@ const commentSchema = new Schema(
       ref: "User",
       type: [ObjectId],
     },
-    timeElapsed : String,
     parentId: {
       ref: "Comment",
       type: ObjectId,
@@ -49,11 +48,12 @@ commentSchema.index({ "author.id": 1, createdAt: -1 });
 commentSchema.index({ likes: 1 });
 /* eslint-enable */
 
-// post-save hook to set timeElapsed property with relative time string generated from createdAt.
-commentSchema.post('save', function(doc) {
-  this.set({ timeElapsed: translateISOtoRelativeTime(doc.createdAt) });
-  this.save();
-});
+commentSchema.set('toObject', { virtuals: true })
+commentSchema.set('toJSON', { virtuals: true })
+
+//set virtual 'timeElapsed' property on Comment POST and Comment PATCH.
+commentSchema.virtual("timeElapsed")
+  .get(function () { return translateISOtoRelativeTime(this.createdAt) });
 
 const Comment = model("Comment", commentSchema);
 

--- a/backend/lib/models/Comment.js
+++ b/backend/lib/models/Comment.js
@@ -1,5 +1,6 @@
 const { Schema, model, ObjectId } = require("mongoose");
 const { schema: authorSchema } = require("./Author");
+const { translateISOtoRelativeTime } = require("../utils");
 
 const commentSchema = new Schema(
   {
@@ -15,6 +16,7 @@ const commentSchema = new Schema(
       ref: "User",
       type: [ObjectId],
     },
+    timeElapsed : String,
     parentId: {
       ref: "Comment",
       type: ObjectId,
@@ -46,6 +48,12 @@ commentSchema.index({ "author.id": 1, createdAt: -1 });
 // Index for like's foreign key for lookup performance
 commentSchema.index({ likes: 1 });
 /* eslint-enable */
+
+// post-save hook to set timeElapsed property with relative time string generated from createdAt.
+commentSchema.post('save', function(doc) {
+  this.set({ timeElapsed: translateISOtoRelativeTime(doc.createdAt) });
+  this.save();
+});
 
 const Comment = model("Comment", commentSchema);
 

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -54,8 +54,8 @@ const timeAgo = (ISODate) => {
   }
 };
 
-const translateISOtoRelativeTime = (ISO) => {
-  return timeAgo(ISO);
+const translateISOtoRelativeTime = (ISODate) => {
+  return timeAgo(ISODate);
 };
 
 module.exports = {

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -1,3 +1,5 @@
+const moment = require("moment");
+
 const generateUUID = ({ range }) => {
   const chars =
     "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -18,10 +20,49 @@ const getCookieToken = (req) => req.cookies.token;
 const emailRegEx = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
 const isValidEmail = (email) => emailRegEx.test(email);
 
+const timeAgo = (ISODate) => {
+  moment.updateLocale("en", {
+    relativeTime: {
+      future: "in %s",
+      past: "%s ago",
+      s: (number) => number + " second ago",
+      ss: "%d seconds ago",
+      m: "1 minute ago",
+      mm: "%d minutes ago",
+      h: "1 hour ago",
+      hh: "%d hours ago",
+      d: "1 day ago",
+      dd: "%d days ago",
+      M: "a month ago",
+      MM: "%d months ago",
+      y: "a year ago",
+      yy: "%d years ago",
+    },
+  });
+
+  const secondsElapsed = moment().diff(ISODate, "seconds");
+  const dayStart = moment().startOf("day").seconds(secondsElapsed);
+
+  if (secondsElapsed > 300) {
+    return moment(ISODate).fromNow(true);
+  } else if (secondsElapsed < 60) {
+    return dayStart.format("s ") + "seconds ago";
+  } else {
+    const minute = dayStart.format("m ");
+    const minuteString = minute > 1 ? " minutes ago" : " minute ago";
+    return minute.concat(minuteString);
+  }
+};
+
+const translateISOtoRelativeTime = (ISO) => {
+  return timeAgo(ISO);
+};
+
 module.exports = {
   bool,
   dateToEpoch,
   generateUUID,
   getCookieToken,
   isValidEmail,
+  translateISOtoRelativeTime,
 };

--- a/client/src/assets/data/formToPostMappings.js
+++ b/client/src/assets/data/formToPostMappings.js
@@ -36,44 +36,6 @@ const translateISOToString = (ISO) => {
   }
 };
 
-const timeAgo = (time) => {
-  moment.updateLocale("en", {
-    relativeTime: {
-      future: "in %s",
-      past: "%s ago",
-      s: (number) => number + "second ago",
-      ss: "%d seconds ago",
-      m: "1 minute ago",
-      mm: "%d minutes ago",
-      h: "1 hour ago",
-      hh: "%d hours ago",
-      d: "1 day ago",
-      dd: "%ddays ago",
-      M: "a month ago",
-      MM: "%d months ago",
-      y: "a year ago",
-      yy: "%d years ago",
-    },
-  });
-
-  let secondsElapsed = moment().diff(time, "seconds");
-  let dayStart = moment().startOf("day").seconds(secondsElapsed);
-
-  if (secondsElapsed > 300) {
-    return moment(time).fromNow(true);
-  } else if (secondsElapsed < 60) {
-    return dayStart.format("s ") + "seconds ago";
-  } else {
-    const minute = dayStart.format("m ");
-    const minuteString = minute > 1 ? " minutes ago" : " minute ago";
-    return minute.concat(minuteString);
-  }
-};
-
-export const translateISOTimeStamp = (ISO) => {
-  return timeAgo(ISO);
-};
-
 export const translateISOTimeTitle = (ISO) => {
   return moment(ISO).format("YYYY-MM-DD HH:mm:ss");
 };

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -11,7 +11,6 @@ import Loader from "components/Feed/StyledLoader";
 import StyledComment from "./StyledComment";
 import { StyledCommentButton } from "./StyledCommentButton";
 import {
-  translateISOTimeStamp,
   translateISOTimeTitle,
 } from "assets/data/formToPostMappings";
 
@@ -231,7 +230,7 @@ const NestedComments = ({
         <StyledComment
           datetime={
             <Tooltip title={translateISOTimeTitle(comment.createdAt)}>
-              <span>{translateISOTimeStamp(comment.createdAt)}</span>
+              <span>{comment?.timeElapsed ? (comment.timeElapsed): ("")}</span>
             </Tooltip>
           }
           author={<span>{comment.author.name}</span>}


### PR DESCRIPTION
Previously, the time ago comment timestamps only updated as you wrote a new comment. 
Now, the timestamps are only updated on page refresh.

Changes:
* moved timeAgo function to the backend and created a Comment post-save hook to set the timeElapsed property to a relative time string generated from the createdAt ISO Date object. 
* Moment relative time timestamps now only update on page refresh. 


Closes #938
Closes #959
