### PR TITLE
Clear Modal state on Modal close

### DIFF
--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -144,13 +144,13 @@ const Step4 = () => {
   );
 };
 
-const CreatePost = ({ toggleModal, ...props }) => {
+const CreatePost = ({ onCancel, ...props }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [form, setForm] = useState({});
   const [postId, setPostId] = useState("");
 
   const clearState = () => {
-    toggleModal();
+    onCancel();
     setCurrentStep(1);
     setForm({});
     setPostId("");

--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -165,7 +165,7 @@ const CreatePost = ({ onCancel, ...props }) => {
         <Step2 user={props.user} />
         <Step4 />
       </Wrapper>
-      <Step3 {...props} />
+      <Step3 onCancel={clearState} {...props} />
     </CreatePostContext.Provider>
   );
 };

--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -144,16 +144,23 @@ const Step4 = () => {
   );
 };
 
-const CreatePost = (props) => {
+const CreatePost = ({ toggleModal, ...props }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [form, setForm] = useState({});
   const [postId, setPostId] = useState("");
+
+  const clearState = () => {
+    toggleModal();
+    setCurrentStep(1);
+    setForm({});
+    setPostId("");
+  };
 
   return (
     <CreatePostContext.Provider
       value={{ form, setForm, currentStep, setCurrentStep, postId, setPostId }}
     >
-      <Wrapper {...props}>
+      <Wrapper onCancel={clearState} {...props}>
         <Step1 />
         <Step2 user={props.user} />
         <Step4 />

--- a/client/src/components/CreatePost/CreatePost.js
+++ b/client/src/components/CreatePost/CreatePost.js
@@ -151,9 +151,11 @@ const CreatePost = ({ onCancel, ...props }) => {
 
   const clearState = () => {
     onCancel();
-    setCurrentStep(1);
-    setForm({});
-    setPostId("");
+    // delay for modal close effect to complete before re-render
+    setTimeout(() => {
+      setCurrentStep(1);
+      setPostId("");
+    }, 200);
   };
 
   return (

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -64,7 +64,7 @@ const initialState = {
   selectedType: "ALL",
   showFilters: false,
   filterModal: false,
-  createPostModal: false,
+  showCreatePostModal: false,
   applyFilters: false,
   activePanel: null,
   location: null,
@@ -188,14 +188,14 @@ const Feed = (props) => {
   const { id } = useParams();
   const [feedState, feedDispatch] = useReducer(feedReducer, {
     ...initialState,
-    createPostModal: id === "create-post",
+    showCreatePostModal: id === "create-post",
   });
   const [selectedOptions, optionsDispatch] = useReducer(optionsReducer, {});
   const [posts, postsDispatch] = useReducer(postsReducer, postsState);
 
   const {
     filterModal,
-    createPostModal,
+    showCreatePostModal,
     activePanel,
     location,
     selectedType,
@@ -268,7 +268,7 @@ const Feed = (props) => {
 
   const handleCreatePost = () => {
     if (isAuthenticated) {
-      dispatchAction(TOGGLE_STATE, "createPostModal");
+      dispatchAction(TOGGLE_STATE, "showCreatePostModal");
     } else {
       history.push(LOGIN);
     }
@@ -426,7 +426,9 @@ const Feed = (props) => {
         providers,
       } = props.history.location.state;
       location && dispatchAction(SET_VALUE, "location", location);
-      const value = Object.keys(HELP_TYPE).find(key => HELP_TYPE[key] === postType);
+      const value = Object.keys(HELP_TYPE).find(
+        (key) => HELP_TYPE[key] === postType,
+      );
       if (postType === HELP_TYPE.REQUEST) {
         // requesting help
         handleChangeType({ key: value });
@@ -592,8 +594,10 @@ const Feed = (props) => {
           </ContentWrapper>
         </LayoutWrapper>
         <CreatePost
-          onCancel={() => dispatchAction(TOGGLE_STATE, "createPostModal")}
-          visible={createPostModal}
+          toggleModal={() =>
+            dispatchAction(TOGGLE_STATE, "showCreatePostModal")
+          }
+          visible={showCreatePostModal}
           user={user}
         />
         {!isLoading && <div id="list-bottom" ref={bottomBoundaryRef}></div>}

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -594,9 +594,7 @@ const Feed = (props) => {
           </ContentWrapper>
         </LayoutWrapper>
         <CreatePost
-          toggleModal={() =>
-            dispatchAction(TOGGLE_STATE, "showCreatePostModal")
-          }
+          onCancel={() => dispatchAction(TOGGLE_STATE, "showCreatePostModal")}
           visible={showCreatePostModal}
           user={user}
         />


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
User can hit 'Create a post' button repeatedly and create new posts. Currently, the success content is shown after first post and remains even after closing and reopening.

closes #876