### PR TITLE
Fixed word-wrap in mobile web

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -19,6 +19,7 @@ import WizardFormNav, {
   StyledButtonWizard,
 } from "components/StepWizard/WizardFormNav";
 import { StyledLoadMoreButton } from "./StyledCommentButton";
+import {StyledPostPagePostCard} from "./StyledPostPage";
 import TextAvatar from "components/TextAvatar";
 import { typeToTag } from "assets/data/formToPostMappings";
 import {
@@ -383,14 +384,8 @@ const Post = ({
     <>
       {postId && dispatchPostAction ? (
         //Post in post's page.
-        <div>
-          <PostCard
-            style={{
-              display: "inline-block",
-              maxWidth: "80rem",
-              marginTop: "1rem",
-            }}
-          >
+        <>
+          <StyledPostPagePostCard>
             <div className="card-header">
               {includeProfileLink ? renderHeaderWithLink : renderHeader}
               <div className="card-submenu">
@@ -432,11 +427,11 @@ const Post = ({
             >
               <p>Are you sure you want to delete the post?</p>
             </WebModal>
-          </PostCard>
+          </StyledPostPagePostCard>
           {showComments && (
             <StyledButtonWizard nav={<WizardFormNav />}></StyledButtonWizard>
           )}
-        </div>
+        </>
       ) : (
         //Post in feed.
         <PostCard>

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -19,7 +19,7 @@ import WizardFormNav, {
   StyledButtonWizard,
 } from "components/StepWizard/WizardFormNav";
 import { StyledLoadMoreButton } from "./StyledCommentButton";
-import {StyledPostPagePostCard} from "./StyledPostPage";
+import { StyledPostPagePostCard } from "./StyledPostPage";
 import TextAvatar from "components/TextAvatar";
 import { typeToTag } from "assets/data/formToPostMappings";
 import {

--- a/client/src/components/Feed/StyledPostPage.js
+++ b/client/src/components/Feed/StyledPostPage.js
@@ -1,0 +1,21 @@
+import { mq,theme } from "constants/theme";
+import styled from "styled-components";
+import PostCard from "./PostCard";
+
+const { darkGray, lightGray, royalBlue, white } = theme.colors;
+
+export const StyledPostPage = styled.div`
+    width: 50%;
+    @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
+        width: 100%;
+        position: relative;
+        overflow-wrap: break-word;
+
+    }      
+`;
+
+export const StyledPostPagePostCard = styled(PostCard)`
+    maxWidth: 80rem;
+    marginTop: 1rem;
+    overflowWrap: break-word;
+`;

--- a/client/src/components/Feed/StyledPostPage.js
+++ b/client/src/components/Feed/StyledPostPage.js
@@ -2,20 +2,17 @@ import { mq,theme } from "constants/theme";
 import styled from "styled-components";
 import PostCard from "./PostCard";
 
-const { darkGray, lightGray, royalBlue, white } = theme.colors;
-
 export const StyledPostPage = styled.div`
-    width: 50%;
-    @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
-        width: 100%;
-        position: relative;
-        overflow-wrap: break-word;
-
-    }      
+  width: 50%;
+  @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
+    width: 100%;
+    position: relative;
+    overflow-wrap: break-word;
+  }      
 `;
 
 export const StyledPostPagePostCard = styled(PostCard)`
-    maxWidth: 80rem;
-    marginTop: 1rem;
-    overflowWrap: break-word;
+  maxWidth: 80rem;
+  marginTop: 1rem;
+  overflowWrap: break-word;
 `;

--- a/client/src/components/Feed/StyledPostPage.js
+++ b/client/src/components/Feed/StyledPostPage.js
@@ -7,12 +7,11 @@ export const StyledPostPage = styled.div`
   @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
     width: 100%;
     position: relative;
-    overflow-wrap: break-word;
   }      
 `;
 
 export const StyledPostPagePostCard = styled(PostCard)`
-  max-width: 80rem;
+  max-width: 100%;
   margin-top: 1rem;
   overflow-wrap: break-word;
   @media screen and (max-width: ${mq.phone.wide.maxWidth}) {

--- a/client/src/components/Feed/StyledPostPage.js
+++ b/client/src/components/Feed/StyledPostPage.js
@@ -1,4 +1,4 @@
-import { mq,theme } from "constants/theme";
+import { mq } from "constants/theme";
 import styled from "styled-components";
 import PostCard from "./PostCard";
 
@@ -12,7 +12,10 @@ export const StyledPostPage = styled.div`
 `;
 
 export const StyledPostPagePostCard = styled(PostCard)`
-  maxWidth: 80rem;
-  marginTop: 1rem;
-  overflowWrap: break-word;
+  max-width: 80rem;
+  margin-top: 1rem;
+  overflow-wrap: break-word;
+  @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
+    margin-top: 2rem;
+  }
 `;

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -4,9 +4,10 @@ import { Modal } from "antd";
 import { useHistory, useParams } from "react-router-dom";
 
 import EditPost from "components/CreatePost/EditPost";
+import Loader from "components/Feed/StyledLoader";
 import { FEED } from "templates/RouteWithSubRoutes";
 import Post, { CONTENT_LENGTH } from "components/Feed/Post";
-import Loader from "components/Feed/StyledLoader";
+import { StyledPostPage } from "components/Feed/StyledPostPage";
 import { typeToTag } from "assets/data/formToPostMappings";
 
 import { postReducer, postState } from "hooks/reducers/postReducers";
@@ -228,7 +229,7 @@ const PostPage = ({
   }, []);
 
   return (
-    <>
+    <StyledPostPage>
       {postId && (
         <PostContext.Provider
           value={{
@@ -279,7 +280,7 @@ const PostPage = ({
           )}
         </PostContext.Provider>
       )}
-    </>
+    </StyledPostPage>
   );
 };
 


### PR DESCRIPTION
Closes #928
Closes #952

You should no longer see div overflow in mobile AND post width should not expand based on content for both web and mobile web. 