### PR TITLE
Add padding to heading from typography to fix sign-in overlap with FP…

### DIFF
--- a/client/src/components/Typography/Heading.js
+++ b/client/src/components/Typography/Heading.js
@@ -10,6 +10,7 @@ const { heading } = theme.typography;
 const Heading = styled(Title)`
   &.ant-typography {
     font-weight: bold;
+    padding: 1rem;
     color: ${(props) => props.color};
     ${heading.font}
   }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Added padding to Heading from components to avoid overlapping when open a keyboard. 

<img width="294" alt="Screen Shot 2020-07-03 at 5 48 42 PM" src="https://user-images.githubusercontent.com/49251966/86502199-70c43c80-bd55-11ea-915c-dffc0de4d75e.png">
<!--### 🚨Before submitting this pull request🚨:-->
<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
