### PR TITLE
Stetting orgs and posts avatar icon to only 1 initial or 2 initials

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -33,6 +33,7 @@ import {
 } from "hooks/actions/postActions";
 import { isAuthorOrg } from "pages/Feed";
 import { authorProfileLink } from "./utils";
+import { getInitialsFromFullName } from "utils/userInfo";
 
 // Icons
 import SvgIcon from "../Icon/SvgIcon";
@@ -79,13 +80,7 @@ const Post = ({
   const [comment, setComment] = useState([]);
 
   const AvatarName =
-    (post?.author?.name &&
-      post.author.name
-        .split(" ") // splitting the name
-        .map((n) => n[0].toUpperCase()) // getting all initials
-        .join("") // uniting all the initials
-        .substring(0, 2)) || // only getting 2 initials
-    "";
+    (post?.author?.name && getInitialsFromFullName(post.author.name)) || "";
 
   // mock API to test functionality
   /* to be removed after full integration with user api */

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -80,7 +80,11 @@ const Post = ({
 
   const AvatarName =
     (post?.author?.name &&
-      post.author.name.match(/\b\w/g).join("").toUpperCase()) ||
+      post.author.name
+        .split(" ") // splitting the name
+        .map((n) => n[0].toUpperCase()) // getting all initials
+        .join("") // uniting all the initials
+        .substring(0, 2)) || // only getting 2 initials
     "";
 
   // mock API to test functionality

--- a/client/src/pages/EditAccount.js
+++ b/client/src/pages/EditAccount.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import Checkbox from "components/Input/Checkbox";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import FormInput from "components/Input/FormInput";
 import ProfilePic from "components/Picture/ProfilePic";
 import { Link } from "react-router-dom";
@@ -76,13 +76,8 @@ function EditAccount(props) {
     mode: "change",
   });
   const { error, loading, user } = userProfileState;
-  const {
-    firstName = "",
-    hide = {},
-    lastName = "",
-    needs = {},
-    objectives = {},
-  } = user || {};
+  const { firstName, hide = {}, lastName, needs = {}, objectives = {} } =
+    user || {};
 
   const handleLocationChange = (location) => {
     setLocation(location);
@@ -149,7 +144,7 @@ function EditAccount(props) {
             <ProfilePic
               resolution={"7680px"}
               noPic={true}
-              initials={getInitials(firstName, lastName)}
+              initials={getInitialsFromFullName(`${firstName} ${lastName}`)}
             />
             {/* hide this until backend API is available
               <ChangePicButton>Change</ChangePicButton> */}

--- a/client/src/pages/EditOrganizationAccount.js
+++ b/client/src/pages/EditOrganizationAccount.js
@@ -44,7 +44,7 @@ import {
 import Marker from "../assets/create-profile-images/location-marker.svg";
 import LocationInput from "../components/Input/LocationInput";
 import ProfilePic from "components/Picture/ProfilePic";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import { refetchUser } from "actions/authActions";
 
 const errorStyles = {
@@ -99,8 +99,7 @@ function EditOrganizationAccount({ refetchUser }) {
       );
     }
     Object.entries(NEEDS).map(([key, label]) => {
-      if (formData.needs[key] === undefined)
-        formData.needs[key] = needs[key];
+      if (formData.needs[key] === undefined) formData.needs[key] = needs[key];
     });
     formData.location = location;
     orgProfileDispatch(updateOrganization());
@@ -277,22 +276,13 @@ function EditOrganizationAccount({ refetchUser }) {
   };
 
   const renderProfilePicture = () => {
-    let firstName, lastName;
     if (organization) {
-      const nameArr = name.split(" ");
-      if (nameArr.length < 2) {
-        firstName = nameArr[0];
-        lastName = firstName.split("").pop();
-      } else {
-        firstName = nameArr[0];
-        lastName = nameArr[1];
-      }
       return (
         <ProfilePicWrapper>
           <ProfilePic
             resolution={"7680px"}
             noPic={true}
-            initials={getInitials(firstName, lastName)}
+            initials={getInitialsFromFullName(name)}
           />
           {/* hide this until backend API is available
           <ChangePicButton>Change</ChangePicButton> */}

--- a/client/src/pages/EditOrganizationProfile.js
+++ b/client/src/pages/EditOrganizationProfile.js
@@ -17,7 +17,7 @@ import {
   MobilePicWrapper,
 } from "../components/EditProfile/EditComponents";
 import ProfilePic from "components/Picture/ProfilePic";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import { validateURL } from "utils/validators";
 import {
   APPLESTORE_URL,
@@ -145,22 +145,13 @@ function EditOrganizationProfile(props) {
   }, [orgProfileDispatch, organizationId]);
 
   const renderProfilePicture = () => {
-    let firstName, lastName;
     if (organization) {
-      const nameArr = name.split(" ");
-      if (nameArr.length < 2) {
-        firstName = nameArr[0];
-        lastName = firstName.split("").pop();
-      } else {
-        firstName = nameArr[0];
-        lastName = nameArr[1];
-      }
       return (
         <ProfilePicWrapper>
           <ProfilePic
             resolution={"7680px"}
             noPic={true}
-            initials={getInitials(firstName, lastName)}
+            initials={getInitialsFromFullName(name)}
           />
           {/* hide this until backend API is available
           <ChangePicButton>Change</ChangePicButton> */}

--- a/client/src/pages/EditProfile.js
+++ b/client/src/pages/EditProfile.js
@@ -33,7 +33,7 @@ import {
   updateUserError,
   updateUserSuccess,
 } from "hooks/actions/userActions";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import { validateURL } from "utils/validators";
 
 const URLS_CONFIG = {
@@ -104,7 +104,7 @@ function EditProfile(props) {
     mode: "change",
   });
   const { error, loading, user } = userProfileState;
-  const { firstName = "", lastName = "", urls = {}, about } = user || {};
+  const { firstName, lastName, urls = {}, about } = user || {};
 
   const onSubmit = async (formData) => {
     userProfileDispatch(updateUser());
@@ -148,7 +148,7 @@ function EditProfile(props) {
           <ProfilePic
             resolution={"7680px"}
             noPic={true}
-            initials={getInitials(firstName, lastName)}
+            initials={getInitialsFromFullName(`${firstName} ${lastName}`)}
           />
         </TitlePictureWrapper>
         {/* hide this until backend API is available

--- a/client/src/pages/OrganizationProfile.js
+++ b/client/src/pages/OrganizationProfile.js
@@ -42,7 +42,7 @@ import {
   CustomDrawer,
 } from "../components/Profile/ProfileComponents";
 import { isAuthorOrg } from "pages/Feed";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import {
   LINKEDIN_URL,
   TWITTER_URL,
@@ -223,28 +223,15 @@ const OrganizationProfile = () => {
   };
 
   const renderProfileData = () => {
-    let firstName, lastName;
     if (!organization) {
       return <p>Loading...</p>;
     } else {
       const { address } = location;
-      const nameArr = name.split(" ");
-      if (nameArr.length < 2) {
-        firstName = nameArr[0];
-        lastName = "";
-      } else {
-        firstName = nameArr[0];
-        lastName = nameArr[1];
-      }
-
       return (
         <>
           <UserInfoContainer>
             {isOwner && <EditIcon src={edit} onClick={() => setDrawer(true)} />}
-            <ProfilePic
-              noPic={true}
-              initials={getInitials(firstName, lastName)}
-            />
+            <ProfilePic noPic={true} initials={getInitialsFromFullName(name)} />
             <UserInfoDesktop>
               <NameDiv>
                 {name}

--- a/client/src/pages/OrganizationProfile.js
+++ b/client/src/pages/OrganizationProfile.js
@@ -231,7 +231,7 @@ const OrganizationProfile = () => {
       const nameArr = name.split(" ");
       if (nameArr.length < 2) {
         firstName = nameArr[0];
-        lastName = firstName.split("").pop();
+        lastName = "";
       } else {
         firstName = nameArr[0];
         lastName = nameArr[1];

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -49,7 +49,7 @@ import {
   fetchUserSuccess,
 } from "hooks/actions/userActions";
 import { UserContext, withUserContext } from "context/UserContext";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 
 // ICONS
 import createPost from "assets/icons/create-post.svg";
@@ -90,8 +90,8 @@ const Profile = ({
   const {
     id: userId,
     about,
-    firstName = "",
-    lastName = "",
+    firstName,
+    lastName,
     location = {},
     needs = {},
     objectives = {},
@@ -101,6 +101,7 @@ const Profile = ({
   const needHelp = Object.values(needs).some((val) => val === true);
   const offerHelp = Object.values(objectives).some((val) => val === true);
   const { address } = location;
+  const fullName = `${firstName} $`;
 
   useEffect(() => {
     (async function fetchProfile() {
@@ -148,7 +149,10 @@ const Profile = ({
       </BackgroundHeader>
       <UserInfoContainer>
         {ownUser && <EditIcon src={edit} onClick={() => setDrawer(true)} />}
-        <ProfilePic noPic={true} initials={getInitials(firstName, lastName)} />
+        <ProfilePic
+          noPic={true}
+          initials={getInitialsFromFullName(`${firstName} ${lastName}`)}
+        />
         <UserInfoDesktop>
           <NameDiv>
             {firstName} {lastName}

--- a/client/src/templates/layouts/NavigationLayout.js
+++ b/client/src/templates/layouts/NavigationLayout.js
@@ -4,7 +4,7 @@ import { Typography } from "antd";
 import React, { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import styled from "styled-components";
-import { getInitials } from "utils/userInfo";
+import { getInitialsFromFullName } from "utils/userInfo";
 import TextAvatar from "components/TextAvatar";
 import Header from "components/Header";
 import Footnote from "components/Footnote";
@@ -13,8 +13,6 @@ import Main from "./Main";
 import MobileTabs from "./MobileTabs";
 import { theme } from "constants/theme";
 
-const NOTION_URL =
-  "https://www.notion.so/fightpandemics/FightPandemics-Overview-cd01dcfc05f24312ac454ac94a37eb5e";
 const { royalBlue, tropicalBlue, white } = theme.colors;
 
 const drawerStyles = {
@@ -176,8 +174,11 @@ const NavigationLayout = (props) => {
 
   const displayInitials = (user) => {
     if (user?.firstName && user?.lastName) {
-      const userinitials = getInitials(user.firstName, user.lastName);
-      return <AvatarInitials>{userinitials}</AvatarInitials>;
+      return (
+        <AvatarInitials>
+          {getInitialsFromFullName(`${user.firstName} ${user.lastName}`)}
+        </AvatarInitials>
+      );
     }
   };
 

--- a/client/src/utils/userInfo.js
+++ b/client/src/utils/userInfo.js
@@ -1,8 +1,7 @@
-export const getInitials = (firstName, lastName) => {
-  return firstName.charAt(0).toUpperCase() + lastName.charAt(0).toUpperCase();
-};
-
 export const getInitialsFromFullName = (fullName) => {
-  const [firstName, lastName] = fullName.split(" ");
-  return firstName.charAt(0).toUpperCase() + lastName.charAt(0).toUpperCase();
+  return fullName
+    .split(" ")
+    .map((n) => n[0].toUpperCase())
+    .join("")
+    .substring(0, 2);
 };


### PR DESCRIPTION
 # What does this pull request aim to achieve? 💯
This PR just fixes the initials in posts and org profile depending on name. If name only 1 word, then the avatar will be 1 letter, but if the name is 2 words or more, then the name will be 2 letters
_Please be concise and link any related issue(s):_
This PR resolves #918 

Here is the outcome of this PR: 
![image](https://user-images.githubusercontent.com/25408660/86521085-235dd300-be1a-11ea-93d7-f187a364adac.png)
