### PR TITLE
Display orgList from individual Profile page

### DIFF
--- a/backend/lib/endpoints/users.js
+++ b/backend/lib/endpoints/users.js
@@ -122,7 +122,7 @@ async function routes(app) {
         userId: authUserId,
       } = req;
 
-      const user = await User.findById(userId);
+      const user = await User.findById(userId).populate("organizations");
       if (user === null) {
         throw app.httpErrors.notFound();
       }
@@ -134,6 +134,7 @@ async function routes(app) {
         id,
         lastName,
         needs,
+        organizations,
         objectives,
         urls,
       } = user;
@@ -154,6 +155,7 @@ async function routes(app) {
         lastName,
         location,
         needs,
+        organizations,
         objectives,
         ownUser: authUserId !== null && authUserId.equals(user.id),
         urls,


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
#### Fixes the bug to display existing organizations list from individual profile page:

<img width="1204" alt="Screen Shot 2020-07-06 at 10 29 21 AM" src="https://user-images.githubusercontent.com/37174253/86621768-9f1f6300-bf73-11ea-97d6-133b75a8098b.png">

_Please be concise and link any related issue(s):_
#1033 
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
