### PR TITLE
On comment PATCH, display an 'edited' tag and the relative update time timestamp in the comment

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -535,6 +535,13 @@ async function routes(app) {
           },
           {
             $addFields: {
+              edited: {
+                $cond: {
+                  if: { $gte: ["$createdAt", "$updatedAt"] },
+                  then: false,
+                  else: true,
+                },
+              },
               childCount: {
                 $size: { $ifNull: ["$children", []] },
               },
@@ -548,7 +555,10 @@ async function routes(app) {
           },
         ]).then((comments) => {
           comments.forEach((comment) => {
-            comment.timeElapsed = translateISOtoRelativeTime(comment.createdAt);
+            comment.createTimeElapsed = translateISOtoRelativeTime(comment.createdAt);
+            comment.editTimeElapsed = translateISOtoRelativeTime(
+              comment.updatedAt,
+            );
           });
           return comments;
         }),

--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 const moment = require("moment");
 
-const { translateISOtoRelativeTime } = require("../utils");
+const { setElapsedTimeText } = require("../utils");
 
 const {
   createCommentSchema,
@@ -535,13 +535,6 @@ async function routes(app) {
           },
           {
             $addFields: {
-              edited: {
-                $cond: {
-                  if: { $gte: ["$createdAt", "$updatedAt"] },
-                  then: false,
-                  else: true,
-                },
-              },
               childCount: {
                 $size: { $ifNull: ["$children", []] },
               },
@@ -555,8 +548,8 @@ async function routes(app) {
           },
         ]).then((comments) => {
           comments.forEach((comment) => {
-            comment.createTimeElapsed = translateISOtoRelativeTime(comment.createdAt);
-            comment.editTimeElapsed = translateISOtoRelativeTime(
+            comment.elapsedTimeText = setElapsedTimeText(
+              comment.createdAt,
               comment.updatedAt,
             );
           });

--- a/backend/lib/models/Comment.js
+++ b/backend/lib/models/Comment.js
@@ -48,12 +48,23 @@ commentSchema.index({ "author.id": 1, createdAt: -1 });
 commentSchema.index({ likes: 1 });
 /* eslint-enable */
 
-commentSchema.set('toObject', { virtuals: true })
-commentSchema.set('toJSON', { virtuals: true })
+commentSchema.set("toObject", { virtuals: true });
+commentSchema.set("toJSON", { virtuals: true });
 
-//set virtual 'timeElapsed' property on Comment POST and Comment PATCH.
-commentSchema.virtual("timeElapsed")
-  .get(function () { return translateISOtoRelativeTime(this.createdAt) });
+//set virtual 'createTimeElapsed' property on Comment POST and Comment PATCH.
+commentSchema.virtual("createTimeElapsed").get(function () {
+  return translateISOtoRelativeTime(this.createdAt);
+});
+
+//set virtual 'editTimeElapsed' property on Comment POST and Comment PATCH.
+commentSchema.virtual("editTimeElapsed").get(function () {
+  return translateISOtoRelativeTime(this.updatedAt);
+});
+
+//set virtual 'edited' property and Boolean value on Comment POST and Comment PATCH.
+commentSchema.virtual("edited").get(function () {
+  return this.createdAt < this.updatedAt;
+});
 
 const Comment = model("Comment", commentSchema);
 

--- a/backend/lib/models/Comment.js
+++ b/backend/lib/models/Comment.js
@@ -1,6 +1,6 @@
 const { Schema, model, ObjectId } = require("mongoose");
 const { schema: authorSchema } = require("./Author");
-const { translateISOtoRelativeTime } = require("../utils");
+const { setElapsedTimeText } = require("../utils");
 
 const commentSchema = new Schema(
   {
@@ -51,19 +51,9 @@ commentSchema.index({ likes: 1 });
 commentSchema.set("toObject", { virtuals: true });
 commentSchema.set("toJSON", { virtuals: true });
 
-//set virtual 'createTimeElapsed' property on Comment POST and Comment PATCH.
-commentSchema.virtual("createTimeElapsed").get(function () {
-  return translateISOtoRelativeTime(this.createdAt);
-});
-
-//set virtual 'editTimeElapsed' property on Comment POST and Comment PATCH.
-commentSchema.virtual("editTimeElapsed").get(function () {
-  return translateISOtoRelativeTime(this.updatedAt);
-});
-
-//set virtual 'edited' property and Boolean value on Comment POST and Comment PATCH.
-commentSchema.virtual("edited").get(function () {
-  return this.createdAt < this.updatedAt;
+//set virtual 'elapsedTimeText' property on Comment POST and Comment PATCH.
+commentSchema.virtual("elapsedTimeText").get(function () {
+  return setElapsedTimeText(this.createdAt, this.updatedAt);
 });
 
 const Comment = model("Comment", commentSchema);

--- a/backend/lib/utils.js
+++ b/backend/lib/utils.js
@@ -20,7 +20,7 @@ const getCookieToken = (req) => req.cookies.token;
 const emailRegEx = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
 const isValidEmail = (email) => emailRegEx.test(email);
 
-const timeAgo = (ISODate) => {
+const translateISOtoRelativeTime = (ISODate) => {
   moment.updateLocale("en", {
     relativeTime: {
       future: "in %s",
@@ -54,8 +54,14 @@ const timeAgo = (ISODate) => {
   }
 };
 
-const translateISOtoRelativeTime = (ISODate) => {
-  return timeAgo(ISODate);
+const setElapsedTimeText = (createdAt, updatedAt) => {
+  if (createdAt < updatedAt) {
+    return `${translateISOtoRelativeTime(
+      createdAt,
+    )} · edited  ${translateISOtoRelativeTime(updatedAt)}`;
+  } else {
+    return translateISOtoRelativeTime(createdAt);
+  }
 };
 
 module.exports = {
@@ -64,5 +70,5 @@ module.exports = {
   generateUUID,
   getCookieToken,
   isValidEmail,
-  translateISOtoRelativeTime,
+  setElapsedTimeText,
 };

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -237,16 +237,18 @@ const NestedComments = ({
       {comment ? (
         <StyledComment
           datetime={
-            <Tooltip title={translateISOTimeTitle(comment.createdAt)}>
-              <span>
-                {comment?.createTimeElapsed ? comment.createTimeElapsed : ""}
-              </span>
-              <span>
-                {comment?.edited && comment?.editTimeElapsed
-                  ? ` · edited  ${comment.editTimeElapsed}`
-                  : ""}
-              </span>
-            </Tooltip>
+            <>
+              <Tooltip title={translateISOTimeTitle(comment.createdAt)}>
+                <span>
+                  {comment?.createTimeElapsed ? comment.createTimeElapsed : ""}
+                </span>
+              </Tooltip>
+              {comment?.edited && comment?.editTimeElapsed && (
+                <Tooltip title={translateISOTimeTitle(comment.editTimeElapsed)}>
+                  <span>{` · edited  ${comment.editTimeElapsed}`}</span>
+                </Tooltip>
+              )}
+            </>
           }
           author={
             <Link to={authorProfileLink(comment)}>{comment.author.name}</Link>

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -240,16 +240,9 @@ const NestedComments = ({
             <>
               <Tooltip title={translateISOTimeTitle(comment.createdAt)}>
                 <span>
-                  {comment?.createTimeElapsed ? comment.createTimeElapsed : ""}
+                  {comment?.elapsedTimeText ? comment.elapsedTimeText : ""}
                 </span>
               </Tooltip>
-              {comment?.edited && comment?.editTimeElapsed && (
-                <Tooltip title={translateISOTimeTitle(comment.updatedAt)}>
-                  <span>
-                    <i>{` · edited  ${comment.editTimeElapsed}`}</i>
-                  </span>
-                </Tooltip>
-              )}
             </>
           }
           author={

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -245,7 +245,9 @@ const NestedComments = ({
               </Tooltip>
               {comment?.edited && comment?.editTimeElapsed && (
                 <Tooltip title={translateISOTimeTitle(comment.editTimeElapsed)}>
-                  <span>{` · edited  ${comment.editTimeElapsed}`}</span>
+                  <span>
+                    <i>{` · edited  ${comment.editTimeElapsed}`}</i>
+                  </span>
                 </Tooltip>
               )}
             </>

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -244,7 +244,7 @@ const NestedComments = ({
                 </span>
               </Tooltip>
               {comment?.edited && comment?.editTimeElapsed && (
-                <Tooltip title={translateISOTimeTitle(comment.editTimeElapsed)}>
+                <Tooltip title={translateISOTimeTitle(comment.updatedAt)}>
                   <span>
                     <i>{` · edited  ${comment.editTimeElapsed}`}</i>
                   </span>

--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -11,9 +11,7 @@ import AutoSize from "components/Input/AutoSize";
 import Loader from "components/Feed/StyledLoader";
 import StyledComment from "./StyledComment";
 import { StyledCommentButton } from "./StyledCommentButton";
-import {
-  translateISOTimeTitle,
-} from "assets/data/formToPostMappings";
+import { translateISOTimeTitle } from "assets/data/formToPostMappings";
 import { authorProfileLink } from "./utils";
 
 // Icons
@@ -161,7 +159,7 @@ const NestedComments = ({
             "commentId",
             commentId,
             "comment",
-            response.data.content,
+            response.data,
           );
           setEditComment(!editComment);
         }
@@ -184,13 +182,21 @@ const NestedComments = ({
 
   const commentActions = [
     <Space size="small">
-      <StyledCommentButton size="small"ghost  onClick={() => toggleEditComment()}>
+      <StyledCommentButton
+        size="small"
+        ghost
+        onClick={() => toggleEditComment()}
+      >
         Edit
       </StyledCommentButton>
-      <StyledCommentButton size="small" ghost onClick={() => handleDeleteComment()}>
+      <StyledCommentButton
+        size="small"
+        ghost
+        onClick={() => handleDeleteComment()}
+      >
         Delete
       </StyledCommentButton>
-    </Space>
+    </Space>,
   ];
 
   const editCommentContent = (
@@ -232,7 +238,14 @@ const NestedComments = ({
         <StyledComment
           datetime={
             <Tooltip title={translateISOTimeTitle(comment.createdAt)}>
-              <span>{comment?.timeElapsed ? (comment.timeElapsed): ("")}</span>
+              <span>
+                {comment?.createTimeElapsed ? comment.createTimeElapsed : ""}
+              </span>
+              <span>
+                {comment?.edited && comment?.editTimeElapsed
+                  ? ` · edited  ${comment.editTimeElapsed}`
+                  : ""}
+              </span>
             </Tooltip>
           }
           author={

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -16,7 +16,7 @@ const StyledComment = styled(Comment)`
     .ant-comment-inner {
       padding: 1rem 0;
       .ant-comment-content {
-        width: 40rem;
+        width: 45rem;
         .ant-comment-content-author-time {
           cursor: default;
           padding-right: 25px;

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -16,8 +16,7 @@ const StyledComment = styled(Comment)`
     .ant-comment-inner {
       padding: 1rem 0;
       .ant-comment-content {
-        min-width: 40rem;
-        max-width: 45rem;
+        width: 40rem;
         .ant-comment-content-author-time {
           cursor: default;
           padding-right: 25px;

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -16,7 +16,8 @@ const StyledComment = styled(Comment)`
     .ant-comment-inner {
       padding: 1rem 0;
       .ant-comment-content {
-        max-width: 30rem;
+        min-width: 40rem;
+        max-width: 45rem;
         .ant-comment-content-author-time {
           cursor: default;
           padding-right: 25px;

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -17,6 +17,7 @@ const StyledComment = styled(Comment)`
       padding: 1rem 0;
       .ant-comment-content {
         width: 45rem;
+        word-break: break-word;
         @media screen and (max-width: ${mq.tablet.wide.maxWidth}) {
           width: 26rem;
         }

--- a/client/src/components/Feed/StyledComment.js
+++ b/client/src/components/Feed/StyledComment.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Comment } from "antd";
-import { theme } from "constants/theme";
+import { mq, theme } from "constants/theme";
 
 const { colors, typography } = theme;
 const { darkGray, lighterGray, white } = colors;
@@ -12,14 +12,16 @@ const StyledComment = styled(Comment)`
     cursor: default;
     font-family: ${display};
     display: inline-block;
-    word-break: break-word;
+    overflow-wrap: break-word;
     .ant-comment-inner {
       padding: 1rem 0;
       .ant-comment-content {
         width: 45rem;
+        @media screen and (max-width: ${mq.tablet.wide.maxWidth}) {
+          width: 26rem;
+        }
         .ant-comment-content-author-time {
           cursor: default;
-          padding-right: 25px;
           color: ${darkGray};
         }
         .ant-comment-content-author {

--- a/client/src/components/Feed/StyledPostPage.js
+++ b/client/src/components/Feed/StyledPostPage.js
@@ -4,7 +4,7 @@ import PostCard from "./PostCard";
 
 export const StyledPostPage = styled.div`
   width: 50%;
-  @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
+  @media screen and (max-width: ${mq.tablet.wide.maxWidth}) {
     width: 100%;
     position: relative;
   }      
@@ -14,7 +14,7 @@ export const StyledPostPagePostCard = styled(PostCard)`
   max-width: 100%;
   margin-top: 1rem;
   overflow-wrap: break-word;
-  @media screen and (max-width: ${mq.phone.wide.maxWidth}) {
+  @media screen and (max-width: ${mq.tablet.wide.maxWidth}) {
     margin-top: 2rem;
   }
 `;

--- a/client/src/hooks/reducers/postReducers.js
+++ b/client/src/hooks/reducers/postReducers.js
@@ -121,7 +121,7 @@ export const postReducer = (state = postState, action) => {
     case SET_COMMENT:
       state.comments = state.comments.map((comment) => {
         if (comment._id === action.commentId) {
-          return { ...comment, content: action.comment };
+          return { ...action.comment };
         } else {
           return comment;
         }


### PR DESCRIPTION
![](https://i.ibb.co/Ttqn6KH/Screen-Shot-2020-07-06-at-5-51-19-PM.png)

Changes:

* Added the property `edited` to the Comments aggregation on GET and set its value to false if  createdAt timestamp is **>=** the updatedAt timestamp. 

* Added a virtual property called `editTimeElapsed` that's a relative time stamp of the updatedAt timestamp. `editTimeElapsed` is only displayed in the frontend if the `edited` property is set to true. 

Closes #1001