### PR TITLE
Display profile and org profile comment's icon and comment count correctly

### DIFF
--- a/client/src/components/Feed/PostSocial.js
+++ b/client/src/components/Feed/PostSocial.js
@@ -71,20 +71,27 @@ const PostSocial = ({
         <div className="social-icon">
           {renderLikeIcon()}
           <span className="total-number">{numLikes}</span>
-          <span className="social-text">{numLikes > 1 ? " Likes" : " Like"}</span>
+          <span className="social-text">
+            {numLikes > 1 ? " Likes" : " Like"}
+          </span>
         </div>
       ) : (
         <div className="social-icon" onClick={() => handlePostLike(id, liked)}>
           {renderLikeIcon()}
           <span className="total-number">{numLikes}</span>
-          <span className="social-text">{numLikes > 1 ? " Likes" : " Like"}</span>
+          <span className="social-text">
+            {numLikes > 1 ? " Likes" : " Like"}
+          </span>
         </div>
       )}
       <span></span>
       {postpage ? (
         <div className="social-icon" onClick={setShowComments}>
           {renderCommentIcon()}
-          <span className="social-text">Comment</span>
+          <div className="total-number">{numComments}</div>
+          <span className="social-text">
+            {numComments > 1 ? " Comments" : " Comment"}
+          </span>
         </div>
       ) : (
         <>
@@ -101,6 +108,9 @@ const PostSocial = ({
               <div className="social-icon" onClick={setShowComments}>
                 {renderCommentIcon()}
                 <div className="total-number">{numComments}</div>
+                <span className="social-text">
+                  {numComments > 1 ? " Comments" : " Comment"}
+                </span>
               </div>
             </Link>
           ) : (

--- a/client/src/components/Feed/PostSocial.js
+++ b/client/src/components/Feed/PostSocial.js
@@ -118,6 +118,9 @@ const PostSocial = ({
               <div className="social-icon">
                 {renderCommentIcon()}
                 <div className="total-number">{numComments}</div>
+                <span className="social-text">
+                  {numComments > 1 ? " Comments" : " Comment"}
+                </span>
               </div>
             </Link>
           )}

--- a/client/src/components/Profile/Activity.js
+++ b/client/src/components/Profile/Activity.js
@@ -17,6 +17,7 @@ const Activity = ({
             <Post
               currentPost={post}
               updateComments={updateComments}
+              numComments={post.commentsCount}
               handlePostDelete={handlePostDelete}
               onSelect={handleEditPost}
               key={key}

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -56,6 +56,7 @@ const PostPage = ({
     editPostModalVisibility,
     deleteModalVisibility,
     loadMorePost,
+    commentsCount,
     showComments,
   } = post;
 
@@ -257,6 +258,7 @@ const PostPage = ({
                 loadMorePost={loadMorePost}
                 onSelect={handleEditPost}
                 showComments={showComments}
+                numComments={commentsCount}
                 onChange={handlePostDelete}
                 handlePostLike={handlePostLike}
                 updateComments={updateComments}


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

I fixed the issue for #931 and now the user profile and organization's profile can show comment's icon as blue and comment count when the post has comments.

_Please be concise and link any related issue(s):_

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
