### PR TITLE
Redirect the user to step 3 after clicking on "Show me posts from anywhere" on step 2 in both offer help and need help pages

### DIFF
--- a/client/src/pages/NeedHelp.js
+++ b/client/src/pages/NeedHelp.js
@@ -91,19 +91,17 @@ const Step2 = (props) => {
             includeNavigator={true}
           />
         </div>
-        <Link to="/feed">
-          <ShowAnywhere
-            id={
-              GTM.requestHelp.prefix +
-              props.currentStep +
-              GTM.wizardNav.showAnywhere
-            }
-            tertiary="true"
-            onSelect={rejectLocationDetection}
-          >
-            Show me postings from anywhere
-          </ShowAnywhere>
-        </Link>
+        <ShowAnywhere
+          id={
+            GTM.requestHelp.prefix +
+            props.currentStep +
+            GTM.wizardNav.showAnywhere
+          }
+          tertiary="true"
+          onClick={rejectLocationDetection}
+        >
+          Show me postings from anywhere
+        </ShowAnywhere>
       </WizardFormWrapper>
     </WizardStep>
   );
@@ -180,7 +178,7 @@ const NeedHelp = withRouter((props) => {
 
   useEffect(() => {
     setTransition(!transition);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateAnswers = (key, value) => {
     const updatedAnswers = { ...state, [key]: value };

--- a/client/src/pages/OfferHelp.js
+++ b/client/src/pages/OfferHelp.js
@@ -106,11 +106,9 @@ const Step2 = (props) => {
             includeNavigator={true}
           />
         </div>
-        <Link to="/feed">
-          <ShowAnywhere tertiary="true" onSelect={rejectLocationDetection}>
-            Show me postings from anywhere
-          </ShowAnywhere>
-        </Link>
+        <ShowAnywhere tertiary="true" onClick={rejectLocationDetection}>
+          Show me postings from anywhere
+        </ShowAnywhere>
       </WizardFormWrapper>
     </WizardStep>
   );
@@ -178,7 +176,7 @@ const OfferHelp = withRouter((props) => {
 
   useEffect(() => {
     setTransition(!transition);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateAnswers = (key, value) => {
     const updatedAnswers = { ...state, [key]: value };


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Redirects user to step 3 during onboarding when the user clicks on`show me posts from anywhere`, this PR also removes some console warnings from these 2 pages. 
_Please be concise and link any related issue(s):_
resolves #1036 
