### PR TITLE
add GET posts/ param to ignoreUserLocation

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -38,8 +38,15 @@ async function routes(app) {
       schema: getPostsSchema,
     },
     async (req) => {
-      const { userId } = req;
-      const { authorId, filter, limit, objective, skip } = req.query;
+      const { query, userId } = req;
+      const {
+        authorId,
+        ignoreUserLocation,
+        filter,
+        limit,
+        objective,
+        skip,
+      } = query;
       const queryFilters = filter ? JSON.parse(decodeURIComponent(filter)) : {};
       let user;
       let userErr;
@@ -64,7 +71,7 @@ async function routes(app) {
       let location;
       if (queryFilters.location) {
         location = queryFilters.location;
-      } else if (user) {
+      } else if (user && !ignoreUserLocation) {
         location = user.location;
       }
 

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -12,6 +12,7 @@ const getPostsSchema = {
   querystring: strictSchema()
     .prop("authorId", S.string())
     .prop("filter", S.string()) // URI encoded JSON; TODO: figure out way to custom validation
+    .prop("ignoreUserLocation", S.boolean().default(false))
     .prop("limit", S.integer())
     .prop("objective", S.string().enum(POST_OBJECTIVES))
     .prop("skip", S.integer()),

--- a/client/src/pages/OrganisationProfile.js
+++ b/client/src/pages/OrganisationProfile.js
@@ -139,7 +139,7 @@ const OrganisationProfile = () => {
     postsDispatch({ type: FETCH_POSTS });
     try {
       const res = await axios.get(
-        `/api/posts?limit=-1&authorId=${organisationId}`,
+        `/api/posts?ignoreUserLocation=true&limit=-1&authorId=${organisationId}`,
       );
       postsDispatch({
         type: SET_POSTS,

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -121,7 +121,9 @@ const Profile = ({
       postsDispatch({ type: FETCH_POSTS });
       try {
         if (userId) {
-          const res = await axios.get(`/api/posts?limit=-1&authorId=${userId}`);
+          const res = await axios.get(
+            `/api/posts?ignoreUserLocation=true&limit=-1&authorId=${userId}`,
+          );
           postsDispatch({
             type: SET_POSTS,
             posts: res.data,


### PR DESCRIPTION
# What does this pull request aim to achieve? 💯

Resolves #904 

@vikjoshi On the org activity page the visibility=city(New York, user is not) can be seen and most recent one is 1st:

![image](https://user-images.githubusercontent.com/10546720/86928099-1daa0b00-c102-11ea-9e3b-b4f05920543e.png)

While on the feed it is hidden.

![image](https://user-images.githubusercontent.com/10546720/86928157-2f8bae00-c102-11ea-81f5-184e7ef96214.png)

Let me know if this is what is expected.


<!--### 🚨Before submitting this pull request🚨:-->


- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
