### PR TITLE
name back to Organizations in airtable script

### DIFF
--- a/backend/scripts/import-posts/map-airtable-data.js
+++ b/backend/scripts/import-posts/map-airtable-data.js
@@ -29,7 +29,8 @@ const cleanType = (airtableType) => {
 
 const cleanAuthorType = (airtableAuthorType) => {
   switch (airtableAuthorType) {
-    case "Organisation": // generic "Organisation" just "Other"
+    // don't rename this to Organisations
+    case "Organization": // generic - make "Other"
       return "Other";
     case "Goverment":
       return "Government";


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #1083 

This one we need to keep as `Organizations` because of Airtable source. I don't see a risk in someone accidentally renaming because the last PR was a one time thing but I put a comment just in case. 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
