### PR TITLE
footer links now display more organized

### DIFF
--- a/client/src/components/Footnote.js
+++ b/client/src/components/Footnote.js
@@ -34,6 +34,10 @@ const Copyright = styled.div`
 
 const Policies = styled.div`
   color: ${colors.darkGray};
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
 
   @media screen and (min-width: ${mq.tablet.wide.minWidth}) {
     margin-top: 1.2rem;

--- a/client/src/components/Footnote.js
+++ b/client/src/components/Footnote.js
@@ -12,6 +12,7 @@ const StyledFooter = styled.footer`
   align-items: center;
   justify-content: center;
 
+  padding: 1rem 2rem;
   width: 100%;
   height: 7.1rem;
 


### PR DESCRIPTION
closes #1113 

<img width="284" alt="Screen Shot 2020-07-10 at 4 03 26 PM" src="https://user-images.githubusercontent.com/53962732/87162925-e59ff500-c2c6-11ea-968c-77a9d42a9d41.png">
