### PR TITLE
fixes ability to like posts after initial signup and before refresh (…

### DIFF
--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -327,7 +327,7 @@ const Feed = (props) => {
     sessionStorage.removeItem("likePost");
 
     if (isAuthenticated) {
-      const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
+      const endPoint = `/api/posts/${postId}/likes/${user?.id || user?._id}`;
       let response = {};
 
       if (user) {

--- a/client/src/pages/Feed.js
+++ b/client/src/pages/Feed.js
@@ -327,7 +327,7 @@ const Feed = (props) => {
     sessionStorage.removeItem("likePost");
 
     if (isAuthenticated) {
-      const endPoint = `/api/posts/${postId}/likes/${user && user.id}`;
+      const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
       let response = {};
 
       if (user) {
@@ -627,7 +627,7 @@ const Feed = (props) => {
                 <FiltersList />
               </FiltersWrapper>
             </div>
-            <FiltersSidebar gtmPrefix={GTM.feed.prefix}/>
+            <FiltersSidebar gtmPrefix={GTM.feed.prefix} />
           </SiderWrapper>
           <ContentWrapper>
             <HeaderWrapper>

--- a/client/src/pages/OrganisationProfile.js
+++ b/client/src/pages/OrganisationProfile.js
@@ -234,7 +234,7 @@ const OrganisationProfile = () => {
   const handlePostLike = async (postId, liked, create) => {
     sessionStorage.removeItem("likePost");
 
-    const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
+    const endPoint = `/api/posts/${postId}/likes/${user?.id || user?._id}`;
     let response = {};
 
     if (user) {

--- a/client/src/pages/OrganisationProfile.js
+++ b/client/src/pages/OrganisationProfile.js
@@ -113,9 +113,7 @@ const OrganisationProfile = () => {
 
   const urlsAndEmail = { ...urls, email };
 
-  const {
-    deleteModalVisibility,
-  } = postsState;
+  const { deleteModalVisibility } = postsState;
 
   useEffect(() => {
     (async function fetchOrgProfile() {
@@ -152,10 +150,12 @@ const OrganisationProfile = () => {
       const res = await axios.get(
         `/api/posts?ignoreUserLocation=true&limit=-1&authorId=${organisationId}`,
       );
-      const loadedPosts = res?.data?.length && res.data.reduce((obj, item) => {
-        obj[item._id] = item;
-        return obj;
-      }, {});
+      const loadedPosts =
+        res?.data?.length &&
+        res.data.reduce((obj, item) => {
+          obj[item._id] = item;
+          return obj;
+        }, {});
 
       postsDispatch({
         type: SET_POSTS,
@@ -234,7 +234,7 @@ const OrganisationProfile = () => {
   const handlePostLike = async (postId, liked, create) => {
     sessionStorage.removeItem("likePost");
 
-    const endPoint = `/api/posts/${postId}/likes/${user && user.id}`;
+    const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
     let response = {};
 
     if (user) {

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -75,7 +75,7 @@ const PostPage = ({ user, updateComments, isAuthenticated }) => {
     sessionStorage.removeItem("likePost");
 
     if (isAuthenticated) {
-      const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
+      const endPoint = `/api/posts/${postId}/likes/${user?.id || user?._id}`;
       let response = {};
 
       if (user) {

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -27,15 +27,12 @@ import {
 import {
   DELETE_MODAL_POST,
   DELETE_MODAL_HIDE,
-  DELETE_MODAL_COMMENT } from "hooks/actions/feedActions";
+  DELETE_MODAL_COMMENT,
+} from "hooks/actions/feedActions";
 
 export const PostContext = React.createContext();
 
-const PostPage = ({
-  user,
-  updateComments,
-  isAuthenticated,
-}) => {
+const PostPage = ({ user, updateComments, isAuthenticated }) => {
   const history = useHistory();
   const { postId } = useParams();
   const [post, postDispatch] = useReducer(postReducer, postState);
@@ -78,7 +75,7 @@ const PostPage = ({
     sessionStorage.removeItem("likePost");
 
     if (isAuthenticated) {
-      const endPoint = `/api/posts/${postId}/likes/${user && user.id}`;
+      const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
       let response = {};
 
       if (user) {

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -42,9 +42,7 @@ import {
   postsReducer,
   postsState as initialPostsState,
 } from "hooks/reducers/feedReducers";
-import {
-  SET_EDIT_POST_MODAL_VISIBILITY,
-} from "hooks/actions/postActions";
+import { SET_EDIT_POST_MODAL_VISIBILITY } from "hooks/actions/postActions";
 import {
   SET_LIKE,
   SET_DELETE_MODAL_VISIBILITY,
@@ -111,9 +109,7 @@ const Profile = ({
   const needHelp = Object.values(needs).some((val) => val === true);
   const offerHelp = Object.values(objectives).some((val) => val === true);
   const { address } = location;
-  const {
-    deleteModalVisibility,
-  } = postsState;
+  const { deleteModalVisibility } = postsState;
 
   useEffect(() => {
     (async function fetchProfile() {
@@ -137,10 +133,12 @@ const Profile = ({
         const res = await axios.get(
           `/api/posts?ignoreUserLocation=true&limit=-1&authorId=${userId}`,
         );
-        const loadedPosts = res?.data?.length && res.data.reduce((obj, item) => {
-          obj[item._id] = item;
-          return obj;
-        }, {});
+        const loadedPosts =
+          res?.data?.length &&
+          res.data.reduce((obj, item) => {
+            obj[item._id] = item;
+            return obj;
+          }, {});
 
         postsDispatch({
           type: SET_POSTS,
@@ -212,7 +210,7 @@ const Profile = ({
   const handlePostLike = async (postId, liked, create) => {
     sessionStorage.removeItem("likePost");
 
-    const endPoint = `/api/posts/${postId}/likes/${user && user.id}`;
+    const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
     let response = {};
 
     if (user) {

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -210,7 +210,7 @@ const Profile = ({
   const handlePostLike = async (postId, liked, create) => {
     sessionStorage.removeItem("likePost");
 
-    const endPoint = `/api/posts/${postId}/likes/${user && user._id}`;
+    const endPoint = `/api/posts/${postId}/likes/${user?.id || user?._id}`;
     let response = {};
 
     if (user) {


### PR DESCRIPTION
resolves issue #1090 

changes:
`const endPoint = \`/api/posts/${postId}/likes/${user && user.id}\`;`
to:
`const endPoint = \`/api/posts/${postId}/likes/${user && user._id}\`;``
in the following files:
  - /client/src/pages/Profile.js
  - /client/src/pages/OrganisationProfile.js
  - /client/src/pages/PostPage.js
  - /client/src/pages/Profile.js

