### PR TITLE
Fix name overflow for org names

### DIFF
--- a/client/src/components/CreatePost/StyledPostAs.js
+++ b/client/src/components/CreatePost/StyledPostAs.js
@@ -114,6 +114,8 @@ const OptionButton = styled(AntDButton)`
     margin-bottom: 1.5rem;
     text-align: left;
     padding-left: 2.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &.ant-btn:hover {


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
#### Fix for overflow of org names that appear in the `createPost` modal.
_Please be concise and link any related issue(s):_
fixes #1120 
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
