### PR TITLE
hide address/coordinates in post(s)

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -178,7 +178,12 @@ async function routes(app) {
         {
           $project: {
             _id: true,
-            author: true,
+            "author.id": true,
+            "author.location.city": true,
+            "author.location.state": true,
+            "author.location.country": true,
+            "author.name": true,
+            "author.type": true,
             commentsCount: {
               $size: { $ifNull: ["$comments", []] },
             },
@@ -296,7 +301,14 @@ async function routes(app) {
     async (req) => {
       const { userId } = req;
       const { postId } = req.params;
-      const [postErr, post] = await app.to(Post.findById(postId));
+      const [postErr, post] = await app.to(
+        Post.findById(postId).select({
+          "author.location.address": false,
+          "author.location.coordinates": false,
+          "author.location.neighborhood": false,
+          "author.location.zip": false,
+        }),
+      );
       if (postErr) {
         req.log.error(postErr, "Failed retrieving post");
         throw app.httpErrors.internalServerError();


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #1143 

As per conversation initiated by Tony in Slack.

This hides the info we definitely don't want to leak - coordinates/address (as well as zip, neighborhood for now since we're not really using it for visibility/sharing yet). 

I wanted a re-usable function for both GET posts/:id & GET posts/ but since one is using aggregation pipeline and the other isn't I didn't see an easy way. Scopes like with sequelize would be nice...

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
