### PR TITLE
Redirect prod subdomains to fightpandemics.com

### DIFF
--- a/terraform-task-module/alb-listener-rule.tf
+++ b/terraform-task-module/alb-listener-rule.tf
@@ -21,3 +21,23 @@ resource "aws_alb_listener_rule" "main" {
     values = [var.fp_context == "production" ? "fightpandemics.com" : "${var.subdomain}.*"]
   }
 }
+
+resource "aws_alb_listener_rule" "redirect" {
+  count        = var.fp_context == "production" ? 1 : 0
+  listener_arn = data.aws_alb_listener.main.arn
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "fightpandemics.com"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = ["*.fightpandemics.com"]
+    }
+  }
+}


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

We want to redirect any random subdomain like thisobviouslyisntarealsubdomain.fightpandemics.com and www.fightpandemics.com to fightpandemics.com. So I added a listener rule to the production load balancer to do a 301 redirect to https://fightpandemics.com.

Resolves #1151 