### PR TITLE
Match rc/* and hotfix/* branches for review workflow

### DIFF
--- a/.github/workflows/review-build-url.yml
+++ b/.github/workflows/review-build-url.yml
@@ -13,7 +13,7 @@ jobs:
         shell: bash
         run: echo "::set-output name=branch::$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH" | tr -cd '[a-zA-Z0-9]_-')"
       - name: Post Review Build URL
-        if: startsWith(steps.get-branch-name-sanitized.outputs.branch, 'feature')
+        if: startsWith(steps.get-branch-name-sanitized.outputs.branch, 'feature') || startsWith(steps.get-branch-name-sanitized.outputs.branch, 'rc') || startsWith(steps.get-branch-name-sanitized.outputs.branch, 'hotfix')
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - feature/**
+      - rc/**
+      - hotfix/**
     paths:
       - backend/**
       - client/**


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Match `rc/*` and `hotfix/*` branches for review workflow so that a review build can be spun up.

The build for `rc/v1.1` will be accessible at rcv11.fightpandemics.work.
