### PR TITLE
add userId in dataLayer of google tag manager

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -24,7 +24,7 @@ const App = (props) => {
   );
 };
 
-const tagManagerArgs = {
+export const tagManagerArgs = {
   gtmId: process.env.REACT_APP_GTM_ID,
 };
 

--- a/client/src/templates/layouts/NavigationLayout.js
+++ b/client/src/templates/layouts/NavigationLayout.js
@@ -5,6 +5,8 @@ import React, { useState, useReducer } from "react";
 import { Link, useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { getInitialsFromFullName } from "utils/userInfo";
+import tagManagerArgs from "App";
+import TagManager from "react-gtm-module";
 import TextAvatar from "components/TextAvatar";
 import CookieAlert from "components/CookieAlert";
 import FeedbackSubmitButton from "components/Button/FeedbackModalButton";
@@ -618,7 +620,12 @@ const NavigationLayout = (props) => {
     </div>
   );
 
-  return <>{renderNavigationBar()}</>;
+  if (isAuthenticated) { 
+    tagManagerArgs['dataLayer'] = {userId: user.id};
+    TagManager.initialize(tagManagerArgs);
+  } 
+
+  return <>{renderNavigationBar()}</>; 
 };
 
 export default NavigationLayout;


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Adding the `userId` to `dataEntry` of google tag manager:

<img width="409" alt="Screen Shot 2020-07-14 at 2 11 06 PM" src="https://user-images.githubusercontent.com/37174253/87476848-ee047280-c5db-11ea-97a7-e8a6bb6955d8.png">

_Please be concise and link any related issue(s):_
fixes #1088
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
