### PR TITLE
clear httpOnly token on logout if online

### DIFF
--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -7,6 +7,8 @@ import {
   SET_USER,
 } from "constants/action-types";
 
+const GET_CURRENT_USER_ENDPOINT = "/api/users/current";
+
 // Token stored in httpOnly cookie set/cleared by server
 export const initAuth = () => {
   return async (dispatch) => {
@@ -14,7 +16,7 @@ export const initAuth = () => {
 
     dispatch({ type: SET_AUTH_LOADING, payload: true });
     try {
-      const { data: user } = await axios.get("/api/users/current");
+      const { data: user } = await axios.get(GET_CURRENT_USER_ENDPOINT);
       dispatch({ type: SET_USER, payload: { user } });
     } catch (error) {
       dispatch({ error, type: AUTH_ERROR });
@@ -27,7 +29,7 @@ export const initAuth = () => {
 export const refetchUser = () => {
   return async (dispatch) => {
     try {
-      const { data: user } = await axios.get("/api/users/current");
+      const { data: user } = await axios.get(GET_CURRENT_USER_ENDPOINT);
       dispatch({ type: SET_USER, payload: { user } });
     } catch (error) {
       dispatch({ error, type: AUTH_ERROR });
@@ -36,8 +38,12 @@ export const refetchUser = () => {
 };
 
 export const authLogout = () => {
-  return (dispatch) => {
+  return async (dispatch) => {
     clearRememberCookie();
+    // also clear httpOnly cookie w jwt token (if online)
+    try {
+      await axios.get(GET_CURRENT_USER_ENDPOINT);
+    } catch {}
     dispatch({ type: AUTH_LOGOUT });
   };
 };


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

This might resolve the cookie issue we are getting with QA #1186  but I'm not 100% sure yet.

Basically we have two cookies for authentication:

1. `token` which contains the actual JWT containing user info. We can only clear this via http (so are dependent on the server). We need it this way  to prevent XSS attacks.
2. `remember` which only exists to enable offline logout. We don't want to be 100% dependent on the server to logout (e.g., if offline) so we have the 2nd non-httpOnly cookie.

If we try to get the user after clearing the `remember` token, the server will clear the `httpOnly` `token`. This might resolve our error we're experiencing with QA, but I'm not 100% sure yet.

But either way, at least for the majority of cases we are clearing both tokens on logout, unless the user is offline. If offline, as before at least they are "signed out" for all practical purposes.

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](https://github.com/FightPandemics/FightPandemics/blob/master/README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`** (need to have cloned the repo not forked).
- [x] This branch is rebased/merged with the **latest master**.
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
