### PR TITLE
Fix Terraform deprecated host_header condition syntax

### DIFF
--- a/terraform-task-module/alb-listener-rule.tf
+++ b/terraform-task-module/alb-listener-rule.tf
@@ -17,8 +17,9 @@ resource "aws_alb_listener_rule" "main" {
     target_group_arn = aws_alb_target_group.app.arn
   }
   condition {
-    field  = "host-header"
-    values = [var.fp_context == "production" ? "fightpandemics.com" : "${var.subdomain}.*"]
+    host_header {
+      values = [var.fp_context == "production" ? "fightpandemics.com" : "${var.subdomain}.*"]
+    }
   }
 }
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Deployment with Terraform is broken because of an update to a new version which deprecated the syntax for the `condition` block for the `aws_alb_listener_rule` resource.

Since this is a critical fix impacting review builds and staging, I will merge this in right away and post an announcement on Slack to rebase the latest from staging to fix deployments.
