### PR TITLE
Pin Terraform versions

### DIFF
--- a/.github/workflows/production-workflow.yml
+++ b/.github/workflows/production-workflow.yml
@@ -52,6 +52,7 @@ jobs:
               region = "eu-west-1"
               key = "production.tfstate"
             }
+            required_version = "~> 0.13"
           }
           EOF
       - run: cat backend.tf
@@ -63,7 +64,7 @@ jobs:
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'init'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
@@ -72,7 +73,7 @@ jobs:
       - name: 'Terraform Apply'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'apply'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/production-workflow.yml
+++ b/.github/workflows/production-workflow.yml
@@ -52,7 +52,7 @@ jobs:
               region = "eu-west-1"
               key = "production.tfstate"
             }
-            required_version = "~> 0.13"
+            required_version = "~> 0.13.0"
           }
           EOF
       - run: cat backend.tf
@@ -61,20 +61,20 @@ jobs:
         name: Get git commit
         shell: bash
         run: echo "::set-output name=hash::$GITHUB_SHA"
-      - name: 'Terraform Init'
+      - name: "Terraform Init"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'init'
+          tf_actions_subcommand: "init"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: eu-west-1
-      - name: 'Terraform Apply'
+      - name: "Terraform Apply"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'apply'
+          tf_actions_subcommand: "apply"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/review-delete-workflow.yml
+++ b/.github/workflows/review-delete-workflow.yml
@@ -25,6 +25,7 @@ jobs:
               region = "us-east-1"
               key = "${{ steps.get-branch-name-sanitized.outputs.branch }}.tfstate"
             }
+            required_version = "~> 0.13"
           }
           EOF
       - run: cat backend.tf
@@ -32,7 +33,7 @@ jobs:
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'init'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
@@ -41,7 +42,7 @@ jobs:
       - name: 'Terraform Destroy'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'destroy'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/review-delete-workflow.yml
+++ b/.github/workflows/review-delete-workflow.yml
@@ -25,25 +25,25 @@ jobs:
               region = "us-east-1"
               key = "${{ steps.get-branch-name-sanitized.outputs.branch }}.tfstate"
             }
-            required_version = "~> 0.13"
+            required_version = "~> 0.13.0"
           }
           EOF
       - run: cat backend.tf
       - run: cat main.tf
-      - name: 'Terraform Init'
+      - name: "Terraform Init"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'init'
+          tf_actions_subcommand: "init"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-      - name: 'Terraform Destroy'
+      - name: "Terraform Destroy"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'destroy'
+          tf_actions_subcommand: "destroy"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
@@ -51,4 +51,3 @@ jobs:
           TF_VAR_env_name: ${{ steps.get-branch-name-sanitized.outputs.branch }}
           TF_VAR_fp_context: review
           TF_VAR_aws_region: us-east-1
-

--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -63,7 +63,7 @@ jobs:
               region = "us-east-1"
               key = "${{ steps.get-branch-name-sanitized.outputs.branch }}.tfstate"
             }
-            required_version = "~> 0.13"
+            required_version = "~> 0.13.0"
           }
           EOF
       - run: cat backend.tf
@@ -72,20 +72,20 @@ jobs:
         name: Get git commit
         shell: bash
         run: echo "::set-output name=hash::$GITHUB_SHA"
-      - name: 'Terraform Init'
+      - name: "Terraform Init"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'init'
+          tf_actions_subcommand: "init"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-      - name: 'Terraform Apply'
+      - name: "Terraform Apply"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'apply'
+          tf_actions_subcommand: "apply"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
@@ -101,5 +101,5 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.REVIEW_AWS_SECRET_ACCESS_KEY }}
-      - name: 'Deployment URL'
+      - name: "Deployment URL"
         run: echo https://${{ steps.get-branch-name-sanitized.outputs.branch }}.fightpandemics.xyz

--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -63,6 +63,7 @@ jobs:
               region = "us-east-1"
               key = "${{ steps.get-branch-name-sanitized.outputs.branch }}.tfstate"
             }
+            required_version = "~> 0.13"
           }
           EOF
       - run: cat backend.tf
@@ -74,7 +75,7 @@ jobs:
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'init'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}
@@ -83,7 +84,7 @@ jobs:
       - name: 'Terraform Apply'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'apply'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -54,7 +54,7 @@ jobs:
               region = "us-east-1"
               key = "staging.tfstate"
             }
-            required_version = "~> 0.13"
+            required_version = "~> 0.13.0"
           }
           EOF
       - run: cat backend.tf
@@ -63,20 +63,20 @@ jobs:
         name: Get git commit
         shell: bash
         run: echo "::set-output name=hash::$GITHUB_SHA"
-      - name: 'Terraform Init'
+      - name: "Terraform Init"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'init'
+          tf_actions_subcommand: "init"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-      - name: 'Terraform Apply'
+      - name: "Terraform Apply"
         uses: hashicorp/terraform-github-actions@master
         with:
           tf_actions_version: 0.13.0
-          tf_actions_subcommand: 'apply'
+          tf_actions_subcommand: "apply"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
@@ -92,4 +92,3 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -54,6 +54,7 @@ jobs:
               region = "us-east-1"
               key = "staging.tfstate"
             }
+            required_version = "~> 0.13"
           }
           EOF
       - run: cat backend.tf
@@ -65,7 +66,7 @@ jobs:
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'init'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
@@ -74,7 +75,7 @@ jobs:
       - name: 'Terraform Apply'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: latest
+          tf_actions_version: 0.13.0
           tf_actions_subcommand: 'apply'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}

--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -9,6 +9,8 @@ terraform {
     region = "us-east-1"
     key = "development.tfstate"
   }
+
+  required_version = "~> 0.13"
 }
 EOF
 

--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -9,8 +9,6 @@ terraform {
     region = "us-east-1"
     key = "development.tfstate"
   }
-
-  required_version = "~> 0.13"
 }
 EOF
 


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

It is best practice to pin the Terraform version to v0.13.0 to avoid breaking changes. While the infrastructure repo needed to be pinned to v0.12.29 for compatibility with the MongoDB Atlas provider, the Terraform code in this repo has worked fine with Terraform v0.13.0, based on the build logs for the past few weeks.

Resolves #1379 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [X] I have checked that no one else is working on similar changes.
- [X] I have read the latest [**README**](README.md) and understand the development workflow.
- [X] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [X] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [X] There are no merge conflicts.
- [X] There are no console warnings and errors.
- [X] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
