### PR TITLE
Fix revival of review build

### DIFF
--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -96,7 +96,7 @@ jobs:
           TF_VAR_aws_region: us-east-1
       - uses: ItsKarma/aws-cli@v1.70.0
         with:
-          args: ecs update-service --cluster review-cluster --service ${{ steps.get-branch-name-sanitized.outputs.branch }} --force-new-deployment
+          args: ecs update-service --cluster review-cluster --service ${{ steps.get-branch-name-sanitized.outputs.branch }} --desired-count 1 --force-new-deployment
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ You can view the build logs in [GitHub Actions](https://github.com/FightPandemic
 
 Note that it may take a few minutes for the app to be accessible, or for changes to be reflected, since it takes time for AWS to spin up the Docker containers.
 
+Please note that review builds are shut down if no new commits are pushed to the branch in more than a day. This is controlled by an AWS Lambda function that runs every day at midnight PST. In order to revive the review build, simply push a new commit to the branch, merge or rebase from staging, or click the "Rerun all jobs" button on the review build page in Github Actions.
+
 ### Staging
 
 When a pull request is merged to staging, it will automatically be deployed to the staging environment. You can view the build logs in [GitHub Actions](https://github.com/FightPandemics/FightPandemics/actions). After the build successfully completes, wait a few minutes for the changes to be reflected, and then access the staging app at http://staging.fightpandemics.work.


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

When a review build is scaled down after a day of inactivity, pushing a new commit or re-running the Github workflow does not revive the build. We need to explicitly set the desired count to 1 to scale it back up.

Tested by going to the AWS ECS console and manually adjusting the desired count of the Fargate service for this review build back to 0 (to simulate the Lambda service killing the review build). After it was scaled down to 0, I re-ran the Github Actions build, and observed the desired count was set back to 1 in the AWS console. After it reached steady state, I tested that the build works by going to the review build URL.

Resolves #1417 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [X] I have checked that no one else is working on similar changes.
- [X] I have read the latest [**README**](README.md) and understand the development workflow.
- [X] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [X] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [X] There are no merge conflicts.
- [X] There are no console warnings and errors.
- [X] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
