### PR TITLE
Recover password screen e2e tests

### DIFF
--- a/cypresse2e/cypress/elements/pages/recoverPassword.js
+++ b/cypresse2e/cypress/elements/pages/recoverPassword.js
@@ -1,0 +1,46 @@
+class RecoverPassword{
+
+    fpLogo = '.am-navbar.am-navbar-light a img';
+    image = '.SocialImageSVG';
+    recoverPasswordPageTitle = "h4";
+    emailField = '#email';
+    recoveryPasswordButton = 'a[role=button]';
+    backToSignInLink = 'a[href="/auth/login"]';
+    errorMessageField = 'small';
+
+    constructor() { }
+
+    visit() {
+        cy.visit('auth/forgot-password');
+    }
+
+    getFpLogo() {
+        return cy.get(this.fpLogo);
+    }
+
+    getRecoverPasswordPageTitle() {
+        return cy.get(this.recoverPasswordPageTitle);
+    }
+
+    getImage() {
+        return cy.get(this.image);
+    }
+
+    getEmailField() {
+        return cy.get(this.emailField);
+    }   
+
+    getRecoveryPasswordButton() {
+        return cy.get(this.recoveryPasswordButton);
+    } 
+
+    getBackToSignInLink() {
+        return cy.get(this.backToSignInLink);
+    } 
+
+    getErrorMessageField() {
+        return cy.get(this.errorMessageField);
+    } 
+
+}
+export default RecoverPassword;

--- a/cypresse2e/cypress/elements/pages/recoverPassword.js
+++ b/cypresse2e/cypress/elements/pages/recoverPassword.js
@@ -4,7 +4,7 @@ class RecoverPassword{
     image = '.SocialImageSVG';
     recoverPasswordPageTitle = "h4";
     emailField = '#email';
-    recoveryPasswordButton = 'a[role=button]';
+    recoverPasswordButton = 'a[role=button]';
     backToSignInLink = 'a[href="/auth/login"]';
     errorMessageField = 'small';
 
@@ -14,24 +14,24 @@ class RecoverPassword{
         cy.visit('auth/forgot-password');
     }
 
-    getFpLogo() {
-        return cy.get(this.fpLogo);
+    getFpLogoLocator() {
+        return this.fpLogo;
     }
 
-    getRecoverPasswordPageTitle() {
-        return cy.get(this.recoverPasswordPageTitle);
+    getRecoverPasswordPageTitleLocator() {
+        return this.recoverPasswordPageTitle;
     }
 
-    getImage() {
-        return cy.get(this.image);
+    getImageLocator() {
+        return this.image;
     }
 
     getEmailField() {
         return cy.get(this.emailField);
     }   
 
-    getRecoveryPasswordButton() {
-        return cy.get(this.recoveryPasswordButton);
+    getRecoverPasswordButton() {
+        return cy.get(this.recoverPasswordButton);
     } 
 
     getBackToSignInLink() {

--- a/cypresse2e/cypress/integration/constants.js
+++ b/cypresse2e/cypress/integration/constants.js
@@ -1,2 +1,4 @@
 export const DUMMY_SAMPLE_EMAIL = 'qa.test@testfpfp.com';
 export const VALID_SAMPLE_EMAIL = 'samplemail.qa@gmail.com';
+export const INVALID_EMAIL_ERROR_MESSAGE = 'Invalid email';
+export const REQUIRED_EMAIL_ERROR_MESSAGE = 'Email is required.';

--- a/cypresse2e/cypress/integration/e2eTests/recoverPassword/recoverPassword.spec.js
+++ b/cypresse2e/cypress/integration/e2eTests/recoverPassword/recoverPassword.spec.js
@@ -1,0 +1,74 @@
+import RecoverPassword from '../../../elements/pages/recoverPassword'
+import {VALID_SAMPLE_EMAIL} from '../../constants';
+import {INVALID_EMAIL_ERROR_MESSAGE} from '../../constants';
+import {REQUIRED_EMAIL_ERROR_MESSAGE} from '../../constants';
+
+describe('FightPandemics Recover Password Page', () => {
+
+    const recoverPassword = new RecoverPassword();
+    var h4Heading = "Recover Password";
+
+
+    context('User is trying to recover password', () => {
+        beforeEach(() => {
+            recoverPassword.visit();
+        });
+
+        it('FP logo is visible and clickable', () => {
+            var fpLogo = recoverPassword.getFpLogo();
+            fpLogo.should('be.visible').and('have.attr', 'alt', 'Fight Pandemics logo').click();
+
+        });
+        
+        it('Recover Password page contains heading and image', () => {          
+            recoverPassword.getRecoverPasswordPageTitle().should('be.visible').contains(h4Heading);
+            recoverPassword.getImage().should('be.visible');
+
+        });
+
+        it('Recover Password button is disabled', () => {
+            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+        });
+
+        it('Leaving email field blank triggers error', () => {
+            var emailField = recoverPassword.getEmailField();
+            emailField.should('be.visible').and('have.attr', 'name', 'email').focus().blur();
+            var emailRequiredErrorMessage = recoverPassword.getErrorMessageField();
+            emailRequiredErrorMessage.should('be.visible');
+            emailRequiredErrorMessage.contains(REQUIRED_EMAIL_ERROR_MESSAGE);
+            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+
+        });
+
+        it('Entering invalid email triggers error', () => {
+            var emailField = recoverPassword.getEmailField();
+            emailField.should('be.visible').and('have.attr', 'name', 'email');
+            emailField.type('qa.test.invalid@').focus().blur();
+            var emailRequiredErrorMessage = recoverPassword.getErrorMessageField();
+            emailRequiredErrorMessage.should('be.visible');
+            emailRequiredErrorMessage.contains(INVALID_EMAIL_ERROR_MESSAGE);
+            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+
+        });
+        
+        it('Entering correct email triggers Recovery Button is enabled', () => {
+            var emailField = recoverPassword.getEmailField();
+            emailField.should('be.visible').and('have.attr', 'name', 'email');
+            emailField.type(VALID_SAMPLE_EMAIL).focus().blur();           
+            var recoveryPasswordButton = recoverPassword.getRecoveryPasswordButton();
+            recoveryPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'false');
+        });
+
+        it('Back to Sign in screen link is visible and clickable', () => {
+            var backToSignInPageLink = recoverPassword.getBackToSignInLink();
+            backToSignInPageLink.should('be.visible');
+            backToSignInPageLink.contains('Back to Sign In screen').click();
+
+        });
+    });
+
+    function checkRecoveryButtonIsDisabled(recoveryPasswordButton){
+        recoveryPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'true')
+    }
+
+});

--- a/cypresse2e/cypress/integration/e2eTests/recoverPassword/recoverPassword.spec.js
+++ b/cypresse2e/cypress/integration/e2eTests/recoverPassword/recoverPassword.spec.js
@@ -3,6 +3,7 @@ import {VALID_SAMPLE_EMAIL} from '../../constants';
 import {INVALID_EMAIL_ERROR_MESSAGE} from '../../constants';
 import {REQUIRED_EMAIL_ERROR_MESSAGE} from '../../constants';
 
+
 describe('FightPandemics Recover Password Page', () => {
 
     const recoverPassword = new RecoverPassword();
@@ -15,39 +16,36 @@ describe('FightPandemics Recover Password Page', () => {
         });
 
         it('FP logo is visible and clickable', () => {
-            var fpLogo = recoverPassword.getFpLogo();
-            fpLogo.should('be.visible').and('have.attr', 'alt', 'Fight Pandemics logo').click();
+            cy.checkFpLogoIsVisibleAndClickable(recoverPassword.getFpLogoLocator());
 
         });
         
         it('Recover Password page contains heading and image', () => {          
-            recoverPassword.getRecoverPasswordPageTitle().should('be.visible').contains(h4Heading);
-            recoverPassword.getImage().should('be.visible');
-
+            cy.pageContainsHeadingAndImage(recoverPassword.getRecoverPasswordPageTitleLocator(),h4Heading, recoverPassword.getImageLocator());
         });
 
         it('Recover Password button is disabled', () => {
-            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+            checkRecoverButtonIsDisabled(recoverPassword.getRecoverPasswordButton());
         });
 
-        it('Leaving email field blank triggers error', () => {
+        it('Leaving email field blank triggers error and Recover Password Button is disabled', () => {
             var emailField = recoverPassword.getEmailField();
             emailField.should('be.visible').and('have.attr', 'name', 'email').focus().blur();
             var emailRequiredErrorMessage = recoverPassword.getErrorMessageField();
             emailRequiredErrorMessage.should('be.visible');
             emailRequiredErrorMessage.contains(REQUIRED_EMAIL_ERROR_MESSAGE);
-            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+            checkRecoverButtonIsDisabled(recoverPassword.getRecoverPasswordButton());
 
         });
 
-        it('Entering invalid email triggers error', () => {
+        it('Entering invalid email triggers error and Recover Password Button is disabled', () => {
             var emailField = recoverPassword.getEmailField();
             emailField.should('be.visible').and('have.attr', 'name', 'email');
             emailField.type('qa.test.invalid@').focus().blur();
             var emailRequiredErrorMessage = recoverPassword.getErrorMessageField();
             emailRequiredErrorMessage.should('be.visible');
             emailRequiredErrorMessage.contains(INVALID_EMAIL_ERROR_MESSAGE);
-            checkRecoveryButtonIsDisabled(recoverPassword.getRecoveryPasswordButton());
+            checkRecoverButtonIsDisabled(recoverPassword.getRecoverPasswordButton());
 
         });
         
@@ -55,8 +53,8 @@ describe('FightPandemics Recover Password Page', () => {
             var emailField = recoverPassword.getEmailField();
             emailField.should('be.visible').and('have.attr', 'name', 'email');
             emailField.type(VALID_SAMPLE_EMAIL).focus().blur();           
-            var recoveryPasswordButton = recoverPassword.getRecoveryPasswordButton();
-            recoveryPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'false');
+            var recoverPasswordButton = recoverPassword.getRecoverPasswordButton();
+            recoverPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'false');
         });
 
         it('Back to Sign in screen link is visible and clickable', () => {
@@ -67,8 +65,8 @@ describe('FightPandemics Recover Password Page', () => {
         });
     });
 
-    function checkRecoveryButtonIsDisabled(recoveryPasswordButton){
-        recoveryPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'true')
+    function checkRecoverButtonIsDisabled(recoverPasswordButton){
+        recoverPasswordButton.invoke('attr', 'aria-disabled').should('contain', 'true')
     }
 
 });

--- a/cypresse2e/cypress/support/commands.js
+++ b/cypresse2e/cypress/support/commands.js
@@ -1,25 +1,11 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('checkFpLogoIsVisibleAndClickable', (fpLogoLocator) => { 
+    var fpLogo = cy.get(fpLogoLocator);
+    fpLogo.should('be.visible').and('have.attr', 'alt', 'Fight Pandemics logo').click();
+});
+
+Cypress.Commands.add('pageContainsHeadingAndImage', (pageHeadingLocator, heading, pageImageLocator) => { 
+    var pageHeading = cy.get(pageHeadingLocator);
+    pageHeading.should('be.visible').contains(heading);
+    var pageImage = cy.get(pageImageLocator);
+    pageImage.should('be.visible');
+});


### PR DESCRIPTION
Contains tests for Recovery Password screen:
-FP logo is visible and clickable
-Recover Password page contains heading and image
-Recover Password button is disabled when screen is open
-Leaving email field blank triggers error and Recover Password button is disabled
-Entering invalid email triggers error and Recover Password button is disabled
-Entering correct email triggers Recovery Button is enabled
-Back to Sign in screen link is visible and clickable

I added custom commands and move some code there. We have the same code verifying logo and page tile/image. So using custom command can help us to keep tests DRY. We could refactor other tests to avoid code repetitions.

I check if button Recover Password is disable when user interacting with email field by entering incorrect email or leave this field empty.

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
