### PR TITLE
Add meta (counts) to GET /posts #1387

### DIFF
--- a/backend/lib/endpoints/posts.js
+++ b/backend/lib/endpoints/posts.js
@@ -46,6 +46,7 @@ async function routes(app) {
         limit,
         objective,
         skip,
+        includeMeta,
       } = query;
       const queryFilters = filter ? JSON.parse(decodeURIComponent(filter)) : {};
       let user;
@@ -132,6 +133,7 @@ async function routes(app) {
 
       // _id starts with seconds timestamp so newer posts will sort together first
       // then in a determinate order (required for proper pagination)
+      /* eslint-disable sort-keys */
       const sortAndFilterSteps = location
         ? [
             {
@@ -150,7 +152,8 @@ async function routes(app) {
             { $sort: { distance: 1, _id: -1 } },
           ]
         : [{ $match: { $and: filters } }, { $sort: { _id: -1 } }];
-
+      /* eslint-enable sort-keys */
+      /* eslint-disable sort-keys */
       const paginationSteps =
         limit === -1
           ? [
@@ -166,10 +169,10 @@ async function routes(app) {
                 $limit: limit || POST_PAGE_SIZE,
               },
             ];
+      /* eslint-enable sort-keys */
 
-      const aggregationPipeline = [
-        ...sortAndFilterSteps,
-        ...paginationSteps,
+      /* eslint-disable sort-keys */
+      const lookupSteps = [
         {
           $lookup: {
             as: "comments",
@@ -178,6 +181,11 @@ async function routes(app) {
             localField: "_id",
           },
         },
+      ];
+      /* eslint-enable sort-keys */
+
+      /* eslint-disable sort-keys */
+      const projectionSteps = [
         {
           $project: {
             _id: true,
@@ -207,19 +215,85 @@ async function routes(app) {
           },
         },
       ];
+      /* eslint-enable sort-keys */
+
+      /* eslint-disable sort-keys */
+      const facetStep = [
+        {
+          $facet: {
+            meta: [
+              { $count: "count" },
+              { $addFields: { skip } },
+              { $addFields: { limit } },
+            ],
+            data: [],
+          },
+        },
+      ];
+      /* eslint-enable sort-keys */
+
+      const aggregationPipelineFormattedOutputResults = [
+        ...sortAndFilterSteps,
+        ...paginationSteps,
+        ...lookupSteps,
+        ...projectionSteps,
+        ...facetStep,
+      ];
+
+      // Get the total results without pagination steps but with filtering aplyed - filtered
+      /* eslint-disable sort-keys */
+      const filteredResults = await Post.aggregate([
+        ...sortAndFilterSteps,
+        ...lookupSteps,
+        { $group: { _id: null, count: { $sum: 1 } } },
+      ]);
+      /* eslint-enable sort-keys */
+
+      const numberFilteredResults = filteredResults[0].count;
 
       const [postsErr, posts] = await app.to(
-        Post.aggregate(aggregationPipeline),
+        Post.aggregate(aggregationPipelineFormattedOutputResults),
       );
+
+      // Total number of posts in db
+      const totalDocuments = await Post.countDocuments();
+
+      // When no documents are found return the same format response
+      /* eslint-disable sort-keys */
+      const emptyResponseData = [
+        {
+          meta: [
+            {
+              count: 0,
+              filtered: numberFilteredResults,
+              limit,
+              skip,
+              total: totalDocuments,
+            },
+          ],
+          data: [],
+        },
+      ];
+      /* eslint-enable sort-keys */
+
+      const metaResponseHandler = (response) => {
+        if (includeMeta) {
+          return response[0];
+        } else {
+          return response[0].data;
+        }
+      };
 
       if (postsErr) {
         req.log.error(postsErr, "Failed requesting posts");
         throw app.httpErrors.internalServerError();
-      } else if (posts === null) {
-        return [];
+      } else if (posts[0].data === null || posts[0].data.length === 0) {
+        return metaResponseHandler(emptyResponseData);
+      } else {
+        posts[0].meta[0].total = totalDocuments;
+        posts[0].meta[0].filtered = numberFilteredResults;
+        return metaResponseHandler(posts);
       }
-
-      return posts;
     },
   );
 

--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -15,7 +15,8 @@ const getPostsSchema = {
     .prop("ignoreUserLocation", S.boolean().default(false))
     .prop("limit", S.integer())
     .prop("objective", S.string().enum(POST_OBJECTIVES))
-    .prop("skip", S.integer()),
+    .prop("skip", S.integer())
+    .prop("includeMeta", S.boolean().default(false)),
 };
 
 const createPostSchema = {


### PR DESCRIPTION
Created includeMeta query parameter (set default to false) that if true sends a response within an envelope. The envelope format is:

{
  "meta": 
     { "total": 456 }
  },
  "data": [{}, {}, {}, {}, {}, {}]
}

### What does this pull request aim to achieve? 💯

_Please be concise and link any related issue(s):_

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
