### PR TITLE
Fix ability to create duplicate organisations

### DIFF
--- a/backend/lib/endpoints/organisations.js
+++ b/backend/lib/endpoints/organisations.js
@@ -179,6 +179,10 @@ async function routes(app) {
           type: body.type,
         }).exec(),
       ])
+        .catch((err) => {
+          req.log.error(err, "Failed creating organisation");
+          throw app.httpErrors.internalServerError();
+        })
         .then((validations) => {
           if (validations[0]) {
             throw app.httpErrors.conflict(
@@ -200,10 +204,6 @@ async function routes(app) {
               "You own an organisation of the same type",
             );
           }
-        })
-        .catch((err) => {
-          req.log.error(err, "Failed creating organisation");
-          throw app.httpErrors.internalServerError();
         });
 
       const [newOrgErr, newOrg] = await app.to(

--- a/backend/lib/endpoints/organisations.js
+++ b/backend/lib/endpoints/organisations.js
@@ -184,26 +184,26 @@ async function routes(app) {
           throw app.httpErrors.internalServerError();
         })
         .then((validations) => {
+          let conflict_message = new String();
           if (validations[0]) {
-            throw app.httpErrors.conflict(
-              "An organisation with the same name already exists",
-            );
+            conflict_message +=
+              "An organisation with the same name already exists";
           }
-          if (validations[1]) {
-            throw app.httpErrors.conflict(
-              "You own an organisation with the same location",
-            );
+          if (validations[1] || validations[2] || validations[3]) {
+            if (validations[0]) conflict_message += ", and y";
+            else conflict_message += "Y";
+            conflict_message += "ou own an organization ";
+            const identical_fields = [];
+            if (validations[1]) identical_fields.push("in the same location");
+            if (validations[2]) identical_fields.push(" of the same industry");
+            if (validations[3]) identical_fields.push(" of the same type");
+            conflict_message += `${identical_fields.join(",")}.`;
+            conflict_message = conflict_message.replace(/,(?=[^,]*$)/, " and");
+          } else if (validations[0]) {
+            conflict_message += ".";
           }
-          if (validations[2]) {
-            throw app.httpErrors.conflict(
-              "You own an organisation of the same industry",
-            );
-          }
-          if (validations[3]) {
-            throw app.httpErrors.conflict(
-              "You own an organisation of the same type",
-            );
-          }
+          if (conflict_message != 0)
+            throw app.httpErrors.conflict(conflict_message);
         });
 
       const [newOrgErr, newOrg] = await app.to(


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
Now users cannot create organizations:

-   with the same name (even if different owners)
-   with the same location (if same owner)
-   of the same type (if same owner)
-   of the same industry (if same owner)

_Please be concise and link any related issue(s):_
fixes #1145 

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
