### PR TITLE
Add port to the mongo service - docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       MONGO_INITDB_DATABASE: fightpandemics
     restart: always
+    ports:
+      - "27017:27017"
     networks:
       - fp_network
 


### PR DESCRIPTION
Port 27017 was added to the mongo service allowing connection with localhost mongoDB:
mongodb://localhost:27017 (MongoDB Compass)

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
