### PR TITLE
ability to delete user account

### DIFF
--- a/backend/lib/components/Auth0.js
+++ b/backend/lib/components/Auth0.js
@@ -73,6 +73,18 @@ const createUser = async (token, payload) => {
   }
 };
 
+const deleteUser = async (token, userId) => {
+  try {
+    const res = await axios.delete(
+      `${AUTH_DOMAIN}/api/v2/users/${userId}`,
+      getAuthHeaders(token),
+    );
+    return res.data;
+  } catch (err) {
+    return wrapError(err);
+  }
+};
+
 const getUser = async (token) => {
   try {
     const res = await axios.get(
@@ -110,5 +122,6 @@ module.exports = {
   buildOauthUrl,
   changePassword,
   createUser,
+  deleteUser,
   getUser,
 };

--- a/client/src/components/EditProfile/EditComponents.js
+++ b/client/src/components/EditProfile/EditComponents.js
@@ -98,6 +98,16 @@ export const CustomSubmitButton = styled(SubmitButton)`
   }
 `;
 
+export const CustomDeleteButton = styled(CustomSubmitButton)`
+  background: ${theme.colors.red};
+  color: ${theme.colors.white};
+  &:hover {
+    background: transparent;
+    border: 1px solid ${theme.colors.red}!important;
+    color: ${theme.colors.red};
+  }
+`;
+
 export const OptionDiv = styled.div`
   display: none;
 

--- a/client/src/hooks/actions/userActions.js
+++ b/client/src/hooks/actions/userActions.js
@@ -20,3 +20,14 @@ export const updateUserSuccess = (user) => ({
   type: UPDATE_USER_SUCCESS,
   user,
 });
+
+export const DELETE_USER = "DELETE_USER";
+export const DELETE_USER_ERROR = "DELETE_USER_ERROR";
+export const DELETE_USER_SUCCESS = "DELETE_USER_SUCCESS";
+
+export const deleteUser = () => ({ type: DELETE_USER });
+export const deleteUserError = (error) => ({ type: DELETE_USER_ERROR, error });
+export const deleteUserSuccess = (message) => ({
+  type: DELETE_USER_SUCCESS,
+  message,
+});

--- a/client/src/hooks/reducers/userReducers.js
+++ b/client/src/hooks/reducers/userReducers.js
@@ -7,6 +7,9 @@ import {
   UPDATE_USER,
   UPDATE_USER_ERROR,
   UPDATE_USER_SUCCESS,
+  DELETE_USER,
+  DELETE_USER_ERROR,
+  DELETE_USER_SUCCESS,
 } from "../actions/userActions";
 
 export const initialState = {
@@ -38,12 +41,16 @@ export const userProfileReducer = (state, action) => {
     case FETCH_USER:
     case UPDATE_USER:
       return { ...state, loading: true, error: null };
+    case DELETE_USER:
     case FETCH_USER_ERROR:
     case UPDATE_USER_ERROR:
+      return { ...state, loading: false, error: payload.error };
+    case DELETE_USER_ERROR:
       return { ...state, loading: false, error: payload.error };
     case FETCH_USER_SUCCESS:
     case UPDATE_USER_SUCCESS:
       return { ...state, loading: false, error: null, user: payload.user };
+    case DELETE_USER_SUCCESS:
     default:
       return state;
   }

--- a/client/src/pages/DeleteAccount.js
+++ b/client/src/pages/DeleteAccount.js
@@ -1,0 +1,189 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import StyledCheckbox from "components/Input/Checkbox";
+import { getInitialsFromFullName } from "utils/userInfo";
+import FormInput from "components/Input/FormInput";
+import ProfilePic from "components/Picture/ProfilePic";
+import { Link } from "react-router-dom";
+import { validateEmail } from "utils/validators";
+
+import {
+  EditLayout,
+  TitlePictureWrapper,
+  FillEmptySpace,
+  CustomLink,
+  CustomForm,
+  CustomHeading,
+  CustomDeleteButton,
+  OptionDiv,
+  FormLayout,
+  ToggleHeading,
+  ProfilePicWrapper,
+  CustomEditAccountHeader,
+  Background,
+} from "../components/EditProfile/EditComponents";
+import { UserContext, withUserContext } from "../context/UserContext";
+import ErrorAlert from "../components/Alert/ErrorAlert";
+import {
+  fetchUser,
+  fetchUserError,
+  fetchUserSuccess,
+  deleteUser,
+  deleteUserError,
+  deleteUserSuccess,
+} from "../hooks/actions/userActions";
+import axios from "axios";
+import styled from "styled-components";
+import { stubTrue } from "lodash";
+
+const Text = styled.p`
+  margin: 2.2rem auto;
+  max-width: 100%;
+  position: relative;
+  
+`;
+const Title = styled.h3`
+  font-weight: bold;
+  line-height: 3rem;
+  color: red;
+`;
+function DeleteAccount(props) {
+  const { userProfileState, userProfileDispatch } = useContext(UserContext);
+  const [consent, setConsent] = useState("");
+  const {
+    clearError,
+    control,
+    errors,
+    formState,
+    handleSubmit,
+    register,
+    setError,
+  } = useForm({
+    mode: "change",
+  });
+  const { error, loading, user } = userProfileState;
+
+  const { firstName, lastName, email } =
+    user || {};
+
+  const handleInputChangeConsent = (e) => {
+    setConsent(e.target.checked);
+  };
+
+  const onSubmit = async (formData) => {
+    if (!consent) {
+      alert("You must agree that this action cannot be undone.");
+      return;
+    }
+    if (formData.email != email) {
+      alert("Email doesn't match");
+      return;
+    }
+    userProfileDispatch(deleteUser());
+    try {
+      const res = await axios.delete("/api/users/");
+      userProfileDispatch(deleteUserSuccess());
+      props.history.push(`/auth/logout`);
+    } catch (err) {
+      const message = err.response?.data?.message || err.message;
+      userProfileDispatch(
+        deleteUserError(`Failed deleting account, reason: ${message}`),
+      );
+    }
+  };
+
+  useEffect(() => {
+    (async function fetchProfile() {
+      userProfileDispatch(fetchUser());
+      try {
+        const res = await axios.get("/api/users/current");
+        userProfileDispatch(fetchUserSuccess(res.data));
+      } catch (err) {
+        const message = err.response?.data?.message || err.message;
+        userProfileDispatch(
+          fetchUserError(`Failed loading profile, reason: ${message}`),
+        );
+      }
+    })();
+  }, [userProfileDispatch]);
+
+  if (loading) return <div>"loading"</div>;
+  return (
+    <Background>
+      <EditLayout>
+        <TitlePictureWrapper>
+          <CustomEditAccountHeader className="h4">
+            Edit Profile
+          </CustomEditAccountHeader>
+          <ToggleHeading>
+            <CustomHeading level={4} className="h4">
+              Delete Acount
+            </CustomHeading>
+          </ToggleHeading>
+          <FillEmptySpace />
+          <ProfilePicWrapper>
+            <ProfilePic
+              resolution={"7680px"}
+              noPic={true}
+              initials={getInitialsFromFullName(`${firstName} ${lastName}`)}
+            />
+            {/* hide this until backend API is available
+              <ChangePicButton>Change</ChangePicButton> */}
+          </ProfilePicWrapper>
+        </TitlePictureWrapper>
+        <FormLayout>
+          <OptionDiv>
+            <CustomLink>
+              <Link to="/edit-account">Account Information</Link>
+            </CustomLink>
+            <CustomLink >
+              <Link to="/edit-profile">Profile Information</Link>
+            </CustomLink>
+            <CustomLink isSelected>
+              <Link to="/delete-account">Delete Account</Link>
+            </CustomLink>
+          </OptionDiv>
+          <CustomForm>
+            {error && <ErrorAlert message={error} type="error" />}
+            <Title>DISCLAIMER</Title>
+            <Text>
+              By deleting your account, all your data will be permanently deleted,
+              If you change your mind, you might not be able to recover it.
+              This includes your profile, organizations you own, comments, and posts.
+            </Text>
+            <FormInput
+              inputTitle="Confirm Email"
+              name="email"
+              type="email"
+              error={errors.email}
+              ref={register({
+                required: "Email is required.",
+                validate: (email) =>
+                  validateEmail(email) || "Invalid email",
+                maxLength: {
+                  value: 200,
+                  message: `Max. 200 characters`,
+                },
+              })}
+            />
+            <StyledCheckbox
+              style={{ fontSize: "1.2rem" }}
+              onChange={handleInputChangeConsent}
+            >
+              I understand that this action cannot be undone.
+            </StyledCheckbox>
+            <CustomDeleteButton
+              disabled={!formState.isValid}
+              primary="true"
+              onClick={handleSubmit(onSubmit)}
+            >
+              Delete Account
+            </CustomDeleteButton>
+          </CustomForm>
+        </FormLayout>
+      </EditLayout>
+    </Background>
+  );
+}
+
+export default withUserContext(DeleteAccount);

--- a/client/src/pages/DeleteAccount.js
+++ b/client/src/pages/DeleteAccount.js
@@ -149,7 +149,7 @@ function DeleteAccount(props) {
             <Text>
               By deleting your account, all your data will be permanently deleted,
               If you change your mind, you might not be able to recover it.
-              This includes your profile, organizations you own, comments, and posts.
+              This includes your profile, organizations you own, and comments and posts by you and all of your organizations.
             </Text>
             <FormInput
               inputTitle="Confirm Email"

--- a/client/src/pages/EditAccount.js
+++ b/client/src/pages/EditAccount.js
@@ -158,6 +158,9 @@ function EditAccount(props) {
             <CustomLink>
               <Link to="/edit-profile">Profile Information</Link>
             </CustomLink>
+            <CustomLink>
+              <Link to="/delete-account">Delete Account</Link>
+            </CustomLink>
           </OptionDiv>
           <CustomForm>
             {error && <ErrorAlert message={error} type="error" />}

--- a/client/src/pages/EditProfile.js
+++ b/client/src/pages/EditProfile.js
@@ -161,6 +161,9 @@ function EditProfile(props) {
             <CustomLink isSelected>
               <Link to="/edit-profile">Profile Information</Link>
             </CustomLink>
+            <CustomLink>
+              <Link to="/delete-account">Delete Account</Link>
+            </CustomLink>
           </OptionDiv>
           <CustomForm>
             {error && <ErrorAlert message={error} type="error" />}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -368,6 +368,9 @@ const Profile = ({
           <DrawerHeader>
             <Link to="/edit-profile">Edit Profile </Link>
           </DrawerHeader>
+          <DrawerHeader>
+            <Link to="/delete-account">Delete Account</Link>
+          </DrawerHeader>
         </CustomDrawer>
       )}
       <WhiteSpace />

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -14,6 +14,7 @@ import CookiesPolicy from "./pages/CookiesPolicy";
 import Profile from "./pages/Profile";
 import EditProfile from "./pages/EditProfile";
 import EditAccount from "./pages/EditAccount";
+import DeleteAccount from "./pages/DeleteAccount";
 import NotFoundPage from "./pages/NotFoundPage";
 import Feed from "./containers/FeedContainer";
 import Login from "./pages/Login";
@@ -178,6 +179,13 @@ const routes = [
   {
     path: "/edit-account",
     component: EditAccount,
+    props: {
+      loggedInOnly: true,
+    },
+  },
+  {
+    path: "/delete-account",
+    component: DeleteAccount,
     props: {
       loggedInOnly: true,
     },


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Ability for users to delete their account, this will include all their organizations, posts and comments.
### important notes: 
- when I try to delete a user account from auth0 i get: 
**`Insufficient scope, expected any of: delete:users,delete:current_user`**
so I commented the part that deletes Auth0 profile, until someone with access to Auth0 adds one of the needed scopes,
then all you have to do is un-commenting that line.
- This needs a front-end re-work, as I am not very familiar with React, and now it's now very mobile friendly.
### how does it look: (not so good)
![preview](https://i.imgur.com/ZS9gcu8.png)
_Please be concise and link any related issue(s):_
closes #1148 


- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
