### PR TITLE
addresses issue 1473

### DIFF
--- a/client/src/components/Feed/NestedComments.js
+++ b/client/src/components/Feed/NestedComments.js
@@ -170,7 +170,8 @@ const NestedComments = ({
     }
   };
 
-  const handleDeleteComment = () => {
+  const handleDeleteComment = (e) => {
+    e.target.blur();
     deleteComment(comment);
   };
 
@@ -190,7 +191,7 @@ const NestedComments = ({
       <StyledCommentButton
         size="small"
         ghost
-        onClick={() => handleDeleteComment()}
+        onClick={(e) => handleDeleteComment(e)}
       >
         Delete
       </StyledCommentButton>
@@ -250,8 +251,8 @@ const NestedComments = ({
           content={editComment ? editCommentContent : renderCommentContent}
         ></StyledComment>
       ) : (
-        <Loader />
-      )}
+          <Loader />
+        )}
     </div>
   );
 };


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Fixes issue that delete comment button remains with blue border after modal window is canceled.
The fix achieves this by blurring the focus off the delete button when it is clicked.
Closes #1473 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [X ] I have checked that no one else is working on similar changes.
- [X ] I have read the latest [**README**](README.md) and understand the development workflow.
- [X ] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [X ] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [X ] There are no merge conflicts.
- [ X] There are no console warnings and errors.
- [ X] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
