### PR TITLE
Feature/1466

### DIFF
--- a/client/src/components/EditProfile/EditComponents.js
+++ b/client/src/components/EditProfile/EditComponents.js
@@ -108,6 +108,7 @@ export const OptionDiv = styled.div`
 `;
 
 export const FormLayout = styled.div`
+  width: 75vw,
   @media screen and (min-width: ${mq.tablet.narrow.minWidth}) {
     display: flex;
     flex-direction: row;

--- a/client/src/components/EditProfile/EditComponents.js
+++ b/client/src/components/EditProfile/EditComponents.js
@@ -6,6 +6,7 @@ import SubmitButton from "../Button/SubmitButton";
 const { colors } = theme;
 
 export const Background = styled.div`
+  width: 95%;
   @media screen and (min-width: ${mq.tablet.narrow.minWidth}) {
     display: flex;
     padding: 3rem 0;
@@ -108,7 +109,6 @@ export const OptionDiv = styled.div`
 `;
 
 export const FormLayout = styled.div`
-  width: 75vw,
   @media screen and (min-width: ${mq.tablet.narrow.minWidth}) {
     display: flex;
     flex-direction: row;

--- a/client/src/components/Input/FormInput.js
+++ b/client/src/components/Input/FormInput.js
@@ -57,25 +57,25 @@ export default forwardRef(
     },
     ref,
   ) => (
-      <OuterWrapper>
-        <Label
-          icon={icon}
-          htmlFor={name}
-          style={blockLabelStyles}
-          label={inputTitle}
+    <OuterWrapper>
+      <Label
+        icon={icon}
+        htmlFor={name}
+        style={blockLabelStyles}
+        label={inputTitle}
+      />
+      <InputWrapper className={error && "has-error"}>
+        {prefix && <Prefix>{prefix}</Prefix>}
+        <FormInput
+          name={name}
+          id={name}
+          defaultValue={defaultValue}
+          ref={ref}
+          placeholder={placeholder}
+          {...props}
         />
-        <InputWrapper className={error && "has-error"}>
-          {prefix && <Prefix>{prefix}</Prefix>}
-          <FormInput
-            name={name}
-            id={name}
-            defaultValue={defaultValue}
-            ref={ref}
-            placeholder={placeholder}
-            {...props}
-          />
-        </InputWrapper>
-        {error && <InputError>{error.message}</InputError>}
-      </OuterWrapper>
-    ),
+      </InputWrapper>
+      {error && <InputError>{error.message}</InputError>}
+    </OuterWrapper>
+  ),
 );

--- a/client/src/components/Input/FormInput.js
+++ b/client/src/components/Input/FormInput.js
@@ -13,6 +13,7 @@ const FormInput = styled.input`
   box-shadow: none;
   color: ${colors.black};
   flex-grow: 1;
+  overflow: auto;
   padding-bottom: 0.5rem;
 `;
 
@@ -56,25 +57,25 @@ export default forwardRef(
     },
     ref,
   ) => (
-    <OuterWrapper>
-      <Label
-        icon={icon}
-        htmlFor={name}
-        style={blockLabelStyles}
-        label={inputTitle}
-      />
-      <InputWrapper className={error && "has-error"}>
-        {prefix && <Prefix>{prefix}</Prefix>}
-        <FormInput
-          name={name}
-          id={name}
-          defaultValue={defaultValue}
-          ref={ref}
-          placeholder={placeholder}
-          {...props}
+      <OuterWrapper>
+        <Label
+          icon={icon}
+          htmlFor={name}
+          style={blockLabelStyles}
+          label={inputTitle}
         />
-      </InputWrapper>
-      {error && <InputError>{error.message}</InputError>}
-    </OuterWrapper>
-  ),
+        <InputWrapper className={error && "has-error"}>
+          {prefix && <Prefix>{prefix}</Prefix>}
+          <FormInput
+            name={name}
+            id={name}
+            defaultValue={defaultValue}
+            ref={ref}
+            placeholder={placeholder}
+            {...props}
+          />
+        </InputWrapper>
+        {error && <InputError>{error.message}</InputError>}
+      </OuterWrapper>
+    ),
 );


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Sets the background element in editComponents to have a base width of 95% so that it does not overflow the screen width and still looks okay given the scrollbar takes up 5px.
The form input text also extended beyond the width of the screen on mobile, so I added 'overflow: auto' to the FormInput component in order to prevent that from happening.
Closes #1466 


<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [ X] I have checked that no one else is working on similar changes.
- [ X] I have read the latest [**README**](README.md) and understand the development workflow.
- [X ] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [X ] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [ X] There are no merge conflicts.
- [X ] There are no console warnings and errors.
- [ ] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
