### PR TITLE
[Mobile UI bug] Org Account drop-down causes page to stretch up to the limits of the screen

### DIFF
--- a/client/src/components/EditProfile/EditComponents.js
+++ b/client/src/components/EditProfile/EditComponents.js
@@ -190,7 +190,7 @@ export const StyledSelect = styled(Select)`
   width: 35%;
   margin-right: 1.8rem;
   @media screen and (max-width: ${mq.tablet.narrow.minWidth}) {
-    width: 60%;
+    width: 100%;
     margin-bottom: 1.8rem;
   }
 `;

--- a/client/src/components/Input/Select.js
+++ b/client/src/components/Input/Select.js
@@ -11,7 +11,7 @@ const StyledSelect = styled(Select)`
   margin-top: 2rem;
   width: 42%;
   @media screen and (max-width: ${mq.tablet.narrow.maxWidth}) {
-    width: 50%;
+    width: 100%;
   }
   .ant-select-selector {
     border: none;


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

#1465 
It fixes the width of Type and Industry dropdowns to fill the screen length on mobile views.
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [ x] I have checked that no one else is working on similar changes.
- [ x] I have read the latest [**README**](README.md) and understand the development workflow.
- [ x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [ x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x ] There are no merge conflicts.
- [x ] There are no console warnings and errors.
- [ x] On the right-hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
