### PR TITLE
Restrict user avatar endpoint to authenticated user

### DIFF
--- a/backend/lib/endpoints/schema/users.js
+++ b/backend/lib/endpoints/schema/users.js
@@ -60,7 +60,6 @@ const createUserSchema = {
 };
 
 const createUserAvatarSchema = {
-  params: strictSchema().prop("userId", S.string().required()),
   body: strictSchema().prop("file", S.required()),
 };
 

--- a/backend/lib/endpoints/users.js
+++ b/backend/lib/endpoints/users.js
@@ -170,11 +170,11 @@ async function routes(app) {
   );
 
   app.post(
-    "/:userId/avatar",
+    "/current/avatar",
     { preValidation: [app.authenticate], schema: createUserAvatarSchema },
     async (req) => {
       const { file } = req.raw.files;
-      const { userId } = req.params;
+      const { userId } = req;
 
       const [err, user] = await app.to(User.findById(userId));
       if (err) {


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

@ashminbhandari found an issue where any user can update another user's avatar. I looked at the code and realized there was no check to see if the user ID passed in the route is the same as the authenticated user ID. I looked at the `GET /api/users/current` and `PATCH /api/users/current` routes and realized that passing in the user ID in the route is unnecessary as it can be extracted from the auth token. I decided to follow the same pattern.

The new route for user avatar upload will be `POST /api/user/current/avatar` (no need to pass in userId through the route - only need the cookie with the auth token).

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix). _(merging into Ashmin's branch)_
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
