### PR TITLE
Frontend e2e tests update for email error messages - RecoverPassword, Login, JoinIn page

### DIFF
--- a/cypresse2e/cypress/integration/constants.js
+++ b/cypresse2e/cypress/integration/constants.js
@@ -1,5 +1,5 @@
 export const DUMMY_SAMPLE_EMAIL = 'qa.test@testfpfp.com';
 export const VALID_SAMPLE_EMAIL = 'samplemail.qa@gmail.com';
-export const INVALID_EMAIL_ERROR_MESSAGE = 'Invalid email';
-export const REQUIRED_EMAIL_ERROR_MESSAGE = 'Email is required.';
+export const INVALID_EMAIL_ERROR_MESSAGE = 'Email address is invalid';
+export const REQUIRED_EMAIL_ERROR_MESSAGE = 'Email address is required';
 export const LOCATION = 'New York';

--- a/cypresse2e/cypress/integration/e2eTests/joinNow/joinNow.spec.js
+++ b/cypresse2e/cypress/integration/e2eTests/joinNow/joinNow.spec.js
@@ -1,4 +1,6 @@
 import JoinNow from '../../../elements/pages/joinNow';
+import {INVALID_EMAIL_ERROR_MESSAGE} from '../../constants';
+import {REQUIRED_EMAIL_ERROR_MESSAGE} from '../../constants';
 
 describe('FightPandemics Sign Up Page', () => {
 
@@ -35,7 +37,7 @@ describe('FightPandemics Sign Up Page', () => {
       emailField.should('be.visible').and('have.attr', 'name', 'email').focus().blur();
       var emailRequired = joinNow.getEmailRequired();
       emailRequired.should('be.visible');
-      emailRequired.contains('small', 'Email is required.');
+      emailRequired.contains('small', REQUIRED_EMAIL_ERROR_MESSAGE);
 
     });
 
@@ -45,7 +47,7 @@ describe('FightPandemics Sign Up Page', () => {
       emailField.type('qa.test@').focus().blur();
       var validEmailRequired = joinNow.getValidEmailRequired();
       validEmailRequired.should('be.visible');
-      validEmailRequired.contains('small', 'Invalid email');
+      validEmailRequired.contains('small', INVALID_EMAIL_ERROR_MESSAGE);
 
     });
 

--- a/cypresse2e/cypress/integration/e2eTests/signIn/signIn.spec.js
+++ b/cypresse2e/cypress/integration/e2eTests/signIn/signIn.spec.js
@@ -1,5 +1,7 @@
 import SignIn from '../../../elements/pages/signIn';
 import { DUMMY_SAMPLE_EMAIL } from '../../constants';
+import {INVALID_EMAIL_ERROR_MESSAGE} from '../../constants';
+import {REQUIRED_EMAIL_ERROR_MESSAGE} from '../../constants';
 
 describe('FightPandemics Sign In Page', () => {
 
@@ -36,7 +38,7 @@ describe('FightPandemics Sign In Page', () => {
             emailField.should('be.visible').and('have.attr', 'name', 'email').focus().blur();
             var emailRequired = signIn.getEmailRequired();
             emailRequired.should('be.visible');
-            emailRequired.contains('Email is required.');
+            emailRequired.contains(REQUIRED_EMAIL_ERROR_MESSAGE);
 
         });
 
@@ -46,7 +48,7 @@ describe('FightPandemics Sign In Page', () => {
             emailField.type('qa.test@').focus().blur();
             var validEmailRequired = signIn.getValidEmailRequired();
             validEmailRequired.should('be.visible');
-            validEmailRequired.contains('Invalid email');
+            validEmailRequired.contains(INVALID_EMAIL_ERROR_MESSAGE);
 
         });
 


### PR DESCRIPTION
Frontend e2e tests update for email error messages - RecoverPassword, Login, JoinIn page
I updated error messages for RecoverPassword, Login, JoinIn page. Tests were  failing. 

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
