### PR TITLE
Fix old avatar caching after updating with new avatar

### DIFF
--- a/backend/lib/components/CDN/index.js
+++ b/backend/lib/components/CDN/index.js
@@ -5,15 +5,17 @@ const path = require("path");
 const { upload } = require("./s3");
 
 async function uploadOrgAvatar(id, file) {
-  const extension = path.extname(file.name);
-  const key = `content/avatars/organisations/${id}${extension}`;
-  await upload(cdn.s3Bucket, key, file.data);
-  return `${cdn.baseUrl}/${key}`;
+  return _uploadAvatar("organisations", id, file);
 }
 
 async function uploadUserAvatar(id, file) {
+  return _uploadAvatar("users", id, file);
+}
+
+async function _uploadAvatar(userType, id, file) {
   const extension = path.extname(file.name);
-  const key = `content/avatars/users/${id}${extension}`;
+  const timestamp = new Date().getTime();
+  const key = `content/avatars/${userType}/${id}-${timestamp}${extension}`;
   await upload(cdn.s3Bucket, key, file.data);
   return `${cdn.baseUrl}/${key}`;
 }


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

This fixes the issue where after updating a user's existing avatar to a new one, the old avatar is still shown due to the Cloudfront distribution caching the image (TTL of 1 hour). AWS [recommends](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/UpdatingExistingObjects.html#ReplacingObjects) versioning files uploaded to S3 as a way to bust the cache.

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix. The branch is created in a cloned version of this repo, **not a forked repo**.
- [] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix). _(Merging to Ashmin's branch for avatar upload)_
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
