### PR TITLE
#1579 Add Redis backend environment variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,10 @@ data "aws_ssm_parameter" "datadog_api_key" {
   name  = "/fp/datadog/key"
 }
 
+data "aws_ssm_parameter" "redis_host" {
+  name  = "/fp/redis/host"
+}
+
 locals {
   app_domain = {
     review      = "fightpandemics.xyz"
@@ -170,6 +174,14 @@ module "main" {
       name  = "LOGGER_PORT",
       value = var.fp_context == "development" ? "1234" : data.aws_ssm_parameter.logger_port[0].value
     },
+    {
+      name  = "REDIS_HOST"
+      value = data.aws_ssm_parameter.redis_host.value
+    },
+    {
+      name  = "REDIS_PORT"
+      value = "6379"
+    }
   ]
   client_env_variables = [
     {


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Adding backend environment variables for Redis, which will point to our ElastiCache cluster. The cluster has been provisioned in different Terraform code.

Branched off of `feature/message-modal/1457` and will be merging into that branch so that it can be used by Socket.IO for direct messaging.

Closes #1579 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [x] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
