### PR TITLE
WIP authorize and set "author"

### DIFF
--- a/backend/lib/endpoints/schema/posts.js
+++ b/backend/lib/endpoints/schema/posts.js
@@ -21,6 +21,7 @@ const getPostsSchema = {
 
 const createPostSchema = {
   body: strictSchema()
+    .prop("authorId", S.string())
     .prop("content", S.string().required())
     .prop("expireAt", S.string().enum(EXPIRATION_OPTIONS).required())
     .prop(
@@ -33,7 +34,6 @@ const createPostSchema = {
     )
     .prop("language", S.array().items(S.string()))
     .prop("objective", S.string().enum(POST_OBJECTIVES).required())
-    .prop("organisationId", S.string())
     .prop("title", S.string().required())
     .prop(
       "types",
@@ -68,15 +68,15 @@ const updatePostSchema = {
 
 const likeUnlikePostSchema = {
   params: strictSchema()
-    .prop("postId", S.string().required())
-    .prop("userId", S.string().required()),
+    .prop("authorId", S.string().required())
+    .prop("postId", S.string().required()),
 };
 
 const likeUnlikeCommentSchema = {
   params: strictSchema()
+    .prop("authorId", S.string().required())
     .prop("postId", S.string().required())
-    .prop("commentId", S.string().required())
-    .prop("userId", S.string().required()),
+    .prop("commentId", S.string().required()),
 };
 
 const deletePostSchema = {
@@ -85,6 +85,7 @@ const deletePostSchema = {
 
 const createCommentSchema = {
   body: strictSchema()
+    .prop("authorId", S.string())
     .prop("content", S.string().required())
     .prop("parentId", S.string()),
   params: strictSchema().prop("postId", S.string().required()),

--- a/client/src/components/CreatePost/Form/Form.js
+++ b/client/src/components/CreatePost/Form/Form.js
@@ -85,7 +85,7 @@ const Form = ({ setCurrentStep, textData, type, setPostId, gtmPrefix }) => {
     populateErrors();
 
     const payload = formDataToPost(formData);
-    if (form.organisationId) payload.organisationId = form.organisationId;
+    if (form.organisationId) payload.authorId = form.organisationId;
 
     if (!errors.length) {
       try {


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Resolves #1470 

I thought we should get at least something for preliminary review from backend perspective. Originally I though merging all would be more ideal but it's turned out the existing design we are targeting has too many question marks and we need to clarify a few things.  

I was hoping there was some kind of very clear authentication policy option like we have with [Laravel](https://laravel.com/docs/8.x/authorization) but I couldn't find anything I was sure about. Here are a few I considered:

1. CASL - https://github.com/stalniy/casl. **Pros**: Isomorphic (could re-use policies on frontend React), integrated with mongoose. **Cons**: A bit confusion and I wasn't sure exactly how to integrate. ?Perhaps limited when it comes to checking role within team (as opposed to overall)? Not sure how well used/maintained it is
1. Casbin -   https://casbin.org/en/. **Pros** multi platform, could re-use policies on frontend React, maybe even native clients? **Cons**. More than a bit confusing.... ?Perhaps limited when it comes to checking role within team (as opposed to overall)?
1. gateman.js - https://github.com/NwangwuOsitadinma/gateman. **Pros**: Works with mongo data model. Might be worth considering later. **Cons**: only BE, doesn't seem well used/maintained. 

Anyways so far my code works with existing post as org/user and will be usable for FE when we find a way to comment/like as an org. But that's it for now (no viewing feed as if org).

@davidoduk @tejasm2 @emtay @CamilaArias 
**When it comes to alignment with product item ** https://www.notion.so/fightpandemics/0562fe39e5364561a0e12f76f19f8996?v=f9b57e5e8a3448e0b63bc4154b38ddf5&p=dd17a9eea26143bf8782ef2a73a19042

Currently it will not quite work with this but could with some modifications... As I raised in Slack recently I think if we are going with this "universal switch" one problem currently is it we need add designs (mobile - to see who is active user) in Figma as well as revamp  flows for some others (e.g. clicking on Organisation in profile menu, create a post flow, more) before I think we can confidently code this approach.

I'm not saying this is the way it has to be forever but maybe adding the user/org toggle in the PostSocial section would be a better option for launch until we clarify requirements and have a comprehensive design in Figma? This is similar to Facebook (personally I think it's also better UX for our use case as well especially considering future org "roles" but that's just me...).

As a reminder from Facebook (IU = Individual User, OU = Organisation User):

1. By default the PostSocial is in the context of yourself (even if during last visit you were the "page/business")
![image](https://user-images.githubusercontent.com/10546720/95367503-d9660c80-08a2-11eb-8ed2-d5f40030e1e0.png)
2. But you can toggle and the context is updated, then you can like/comment etc as the selected org
![image](https://user-images.githubusercontent.com/10546720/95367948-67da8e00-08a3-11eb-9a00-283db7ac86b3.png)

When it comes to messaging it's pretty straight forward... You visit the org page and then the context is switched you can message as that org (OR not if you don't have the permission later). 

Just ideas we can discuss further through some other forum
 
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [x] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
