### PR TITLE
Do not initialize GTM when a QA localStorage key is set

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -20,7 +20,8 @@ const tagManagerArgs = {
   gtmId: process.env.REACT_APP_GTM_ID,
 };
 
-TagManager.initialize(tagManagerArgs);
+if (localStorage.getItem("fp_qa") == "true")
+  TagManager.initialize(tagManagerArgs);
 
 const store = createStore(rootReducer, applyMiddleware(thunk));
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -20,7 +20,7 @@ const tagManagerArgs = {
   gtmId: process.env.REACT_APP_GTM_ID,
 };
 
-if (localStorage.getItem("fp_qa") == "true")
+if (localStorage.getItem("fp_qa") != "true")
   TagManager.initialize(tagManagerArgs);
 
 const store = createStore(rootReducer, applyMiddleware(thunk));

--- a/client/src/pages/ToggleQAMode.js
+++ b/client/src/pages/ToggleQAMode.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-const ToggleQAMode = ({ history }) => {
+const ToggleQAMode = () => {
   const newVal = !(localStorage.getItem("fp_qa") == "true");
   localStorage.setItem("fp_qa", newVal);
   alert(`QA mode is now ${newVal ? "enabled" : "disabled"}`);
-  history.replace("/");
+  window.location = "/";
   return null;
 };
 

--- a/client/src/pages/ToggleQAMode.js
+++ b/client/src/pages/ToggleQAMode.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-const ToggleQAMode = ({ history }) => {
+const ToggleQAMode = () => {
   const newVal = !(localStorage.getItem("fp_qa") == "true");
   localStorage.setItem("fp_qa", newVal);
   alert(`QA mode is now ${newVal ? "enabled" : "disabled"}`);
-  history.push("/");
+  window.location.reload();
   return null;
 };
 

--- a/client/src/pages/ToggleQAMode.js
+++ b/client/src/pages/ToggleQAMode.js
@@ -1,10 +1,10 @@
 import React from "react";
 
-const ToggleQAMode = () => {
+const ToggleQAMode = ({ history }) => {
   const newVal = !(localStorage.getItem("fp_qa") == "true");
   localStorage.setItem("fp_qa", newVal);
   alert(`QA mode is now ${newVal ? "enabled" : "disabled"}`);
-  window.location.reload();
+  history.replace("/");
   return null;
 };
 

--- a/client/src/pages/ToggleQAMode.js
+++ b/client/src/pages/ToggleQAMode.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const ToggleQAMode = ({ history }) => {
+  const newVal = !(localStorage.getItem("fp_qa") == "true");
+  localStorage.setItem("fp_qa", newVal);
+  alert(`QA mode is now ${newVal ? "enabled" : "disabled"}`);
+  history.push("/");
+  return null;
+};
+
+export default ToggleQAMode;

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -24,6 +24,7 @@ import ProfileCompleted from "./pages/ProfileCompleted";
 import CreateUserProfile from "./pages/CreateUserProfile";
 import Logout from "./pages/Logout";
 import Faq from "./pages/Faq";
+import ToggleQAMode from "./pages/ToggleQAMode.js";
 
 const routes = [
   {
@@ -212,6 +213,10 @@ const routes = [
   {
     path: "/faq",
     component: Faq,
+  },
+  {
+    path: "/toggleqa",
+    component: ToggleQAMode,
   },
   {
     path: "*",


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
adds a "hidden" route to set a "QA mode" localStorage key that if "true" GTM doesn't get initialized and no data is sent to Google Analytics.
we had to add a hidden route in order to be able to set the key on mobile too.

You can go to `/toggleqa` to toggle the "QA Mode"

_Please be concise and link any related issue(s):_
closes #1667 
<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [x] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
