### PR TITLE
added minWidth prop to StyledSelector to fix selector item text cutoff

### DIFF
--- a/client/src/components/CreatePost/Form/ThirdSection.js
+++ b/client/src/components/CreatePost/Form/ThirdSection.js
@@ -36,6 +36,7 @@ const Third = ({ onShareWithChange, onExpirationChange, formData }) => {
             }
             filterOption={false}
             options={translateOptions(shareWith.options)}
+            minWidth="13rem"
           />
           <Selector
             suffixIcon={

--- a/client/src/components/Selector/Selector.js
+++ b/client/src/components/Selector/Selector.js
@@ -10,6 +10,7 @@ const BaseSelector = ({
   suffixIcon,
   filterOptions,
   defaultValue,
+  minWidth
 }) => (
   <StyledSelector
     suffixIcon={suffixIcon}
@@ -19,6 +20,7 @@ const BaseSelector = ({
     getPopupContainer={() =>
       document.getElementsByClassName("ant-modal-body")[0]
     }
+    minWidth={minWidth}
   >
     {options.map((item) => (
       <Option {...optionProps} key={item.value} value={item.value}>

--- a/client/src/components/Selector/StyledSelector.js
+++ b/client/src/components/Selector/StyledSelector.js
@@ -9,7 +9,7 @@ const StyledSelector = styled(Select)`
   margin: 0.5rem;
 
   .ant-select-selector {
-    min-width: 11rem;
+    min-width: ${props => props.minWidth || "11rem"};
     height: 2.25rem !important;
     border: 0.1rem solid ${colors.royalBlue} !important;
     border-radius: 0.5rem !important;


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
fix text cutoff for post visibility popup
before: 
![image](https://user-images.githubusercontent.com/56363473/100263306-587ad700-2f1b-11eb-93fb-2b6402c717bd.png)
after: 
![image](https://user-images.githubusercontent.com/56363473/100263413-78aa9600-2f1b-11eb-998d-cc026e8928e5.png)

I just added a minWidth prop to Selector and passed it down to StyledSelector. Also, this my first PR to this repo so please let me know if I am doing something wrong or if this wasn't an adequate solution to the issue.


_Please be concise and link any related issue(s):_fixes issue #1923 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x ] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x ] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x ] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [x] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
