### PR TITLE
Add manual destroy review workflow

### DIFF
--- a/.github/workflows/review-delete-workflow copy.yml
+++ b/.github/workflows/review-delete-workflow copy.yml
@@ -1,8 +1,11 @@
-name: Delete Review Build
+name: Delete Review Build (Manual)
 
 on:
-  pull_request:
-    types: [closed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Review branch to delete
+        required: true
 
 jobs:
   destroy_review:
@@ -12,7 +15,7 @@ jobs:
       - id: get-branch-name-sanitized
         name: Sanitize branch name
         shell: bash
-        run: echo "::set-output name=branch::$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH" | tr -cd '[a-zA-Z0-9]-' | cut -b 1-40)"
+        run: echo "::set-output name=branch::$(${{github.event.inputs.branch}} | tr -cd '[a-zA-Z0-9]-' | cut -b 1-40)"
       - env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.REVIEW_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯

Revert branch delete trigger (doesn't work), and add manual destroy review workflow so that we can delete stale review builds

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [x] I have read the latest [**README**](README.md) and understand the development workflow.
- [ ] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [ ] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [ ] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
