### PR TITLE
Feature/2126 translate on support button

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14962,6 +14962,14 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-zendesk": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/react-zendesk/-/react-zendesk-0.1.10.tgz",
+      "integrity": "sha512-QDqHfk2tK1QzWubOnNEWxmyexKIXV3j0w7LjZ161z2K2DmkaPErIDwtBokQVgvzDvM7S657S2DbQY9vIYQsf0g==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "react-step-wizard": "^5.3.2",
     "react-transition-group": "^4.4.1",
     "react-virtualized": "^9.21.2",
+    "react-zendesk": "^0.1.10",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "snyk": "^1.319.2",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -114,11 +114,5 @@
         e.appendChild(s);
       })();
     </script>
-    <!-- Start of fightpandemics Zendesk Widget script -->
-    <script
-    id="ze-snippet"
-    src="https://static.zdassets.com/ekr/snippet.js?key=95ac876b-8717-438b-ac57-7a2239714c9b">
-    </script>
-    <!-- End of fightpandemics Zendesk Widget script -->
   </body>
 </html>

--- a/client/src/components/CreatePost/Form/TabForms.js
+++ b/client/src/components/CreatePost/Form/TabForms.js
@@ -27,36 +27,27 @@ const ModalComponent = ({
   gtmTagPrefix,
 }) => {
   const { t } = useTranslation();
+
   // default tabs
-  let tabs = [
-    {
+  const tabs = [];
+  const typeOfHelp = [
+    {'offer':{
       key: "offer",
       title: t("post.givingHelp"),
       question: t("post.whatGiving"),
-    },
-    {
+  }},
+    {'request':{
       key: "request",
       title: t("post.gettingHelp"),
       question: t("post.whatNeed"),
-    },
-  ];
+  }}]
+
   // if editing post then set tab to show
   if (currentPost){
-    if (currentPost.objective === "offer"){
-      tabs = [
-        {
-        key: "offer",
-        title: t("post.givingHelp"),
-        question: t("post.whatGiving"),
-        }
-      ]
-    } else if (currentPost.objective === 'request') {
-      tabs=[{key: "request",
-      title: t("post.gettingHelp"),
-      question: t("post.whatNeed"),
-      }]
+    if (currentPost.objective){
+      tabs.push(typeOfHelp[`${currentPost.objective}`])
+      }
     }
-}
 
   const [showModal, setShowModal] = useState(true);
   const closeModal = () => (onClose ? onClose() : setShowModal(false));

--- a/client/src/components/CreatePost/Form/TabForms.js
+++ b/client/src/components/CreatePost/Form/TabForms.js
@@ -27,27 +27,31 @@ const ModalComponent = ({
   gtmTagPrefix,
 }) => {
   const { t } = useTranslation();
-
-  // default tabs
   const tabs = [];
-  const typeOfHelp = [
-    {'offer':{
+  const typeOfHelp = {
+    "offer":{
       key: "offer",
       title: t("post.givingHelp"),
       question: t("post.whatGiving"),
-  }},
-    {'request':{
+    },
+    "request":{
       key: "request",
       title: t("post.gettingHelp"),
       question: t("post.whatNeed"),
-  }}]
+    }
+  }
 
-  // if editing post then set tab to show
   if (currentPost){
     if (currentPost.objective){
+      // add only specific Tab if there is already an objective "request/offer"
       tabs.push(typeOfHelp[`${currentPost.objective}`])
-      }
     }
+  } else {
+    // add all keys if no objective is found or is undefined
+    for (let key of Object.keys(typeOfHelp)){
+      tabs.push(typeOfHelp[key])
+    }
+  }
 
   const [showModal, setShowModal] = useState(true);
   const closeModal = () => (onClose ? onClose() : setShowModal(false));

--- a/client/src/components/CreatePost/Form/TabForms.js
+++ b/client/src/components/CreatePost/Form/TabForms.js
@@ -40,22 +40,23 @@ const ModalComponent = ({
       question: t("post.whatNeed"),
     },
   ];
-
   // if editing post then set tab to show
-  if (currentPost.objective === "offer"){
-    tabs = [
-      {
-      key: "offer",
-      title: t("post.givingHelp"),
-      question: t("post.whatGiving"),
-      }
-    ]
-  } else {
-    tabs=[{key: "request",
-    title: t("post.gettingHelp"),
-    question: t("post.whatNeed"),
-    }]
-  }
+  if (currentPost){
+    if (currentPost.objective === "offer"){
+      tabs = [
+        {
+        key: "offer",
+        title: t("post.givingHelp"),
+        question: t("post.whatGiving"),
+        }
+      ]
+    } else if (currentPost.objective === 'request') {
+      tabs=[{key: "request",
+      title: t("post.gettingHelp"),
+      question: t("post.whatNeed"),
+      }]
+    }
+}
 
   const [showModal, setShowModal] = useState(true);
   const closeModal = () => (onClose ? onClose() : setShowModal(false));

--- a/client/src/components/CreatePost/Form/TabForms.js
+++ b/client/src/components/CreatePost/Form/TabForms.js
@@ -27,31 +27,18 @@ const ModalComponent = ({
   gtmTagPrefix,
 }) => {
   const { t } = useTranslation();
-  const tabs = [];
-  const typeOfHelp = {
-    "offer":{
+  const tabs = [
+    {
       key: "offer",
       title: t("post.givingHelp"),
       question: t("post.whatGiving"),
     },
-    "request":{
+    {
       key: "request",
       title: t("post.gettingHelp"),
       question: t("post.whatNeed"),
-    }
-  }
-
-  if (currentPost){
-    if (currentPost.objective){
-      // add only specific Tab if there is already an objective "request/offer"
-      tabs.push(typeOfHelp[`${currentPost.objective}`])
-    }
-  } else {
-    // add all keys if no objective is found or is undefined
-    for (let key of Object.keys(typeOfHelp)){
-      tabs.push(typeOfHelp[key])
-    }
-  }
+    },
+  ];
 
   const [showModal, setShowModal] = useState(true);
   const closeModal = () => (onClose ? onClose() : setShowModal(false));
@@ -76,21 +63,21 @@ const ModalComponent = ({
       >
         {currentPost
           ? tabs.map((tab) => (
-            <TabPane tab={tab.title}>
-            <EditForm
-              type={tab.key}
-              textData={{ question: tab.question }}
-              onClose={onClose}
-              loadPost={loadPost}
-              fullContent={fullContent}
-              dispatchAction={dispatchAction}
-              currentPost={currentPost}
-              user={user}
-              onSelect={handleEditPost}
-              isAuthenticated={isAuthenticated}
-              onCancel={handleCloseEditPost}
-            />
-          </TabPane>
+              <TabPane tab={tab.title} key={tab.key}>
+                <EditForm
+                  type={tab.key}
+                  textData={{ question: tab.question }}
+                  onClose={onClose}
+                  loadPost={loadPost}
+                  fullContent={fullContent}
+                  dispatchAction={dispatchAction}
+                  currentPost={currentPost}
+                  user={user}
+                  onSelect={handleEditPost}
+                  isAuthenticated={isAuthenticated}
+                  onCancel={handleCloseEditPost}
+                />
+              </TabPane>
             ))
           : tabs.map((tab) => (
               <TabPane

--- a/client/src/components/CreatePost/Form/TabForms.js
+++ b/client/src/components/CreatePost/Form/TabForms.js
@@ -27,7 +27,8 @@ const ModalComponent = ({
   gtmTagPrefix,
 }) => {
   const { t } = useTranslation();
-  const tabs = [
+  // default tabs
+  let tabs = [
     {
       key: "offer",
       title: t("post.givingHelp"),
@@ -39,6 +40,22 @@ const ModalComponent = ({
       question: t("post.whatNeed"),
     },
   ];
+
+  // if editing post then set tab to show
+  if (currentPost.objective === "offer"){
+    tabs = [
+      {
+      key: "offer",
+      title: t("post.givingHelp"),
+      question: t("post.whatGiving"),
+      }
+    ]
+  } else {
+    tabs=[{key: "request",
+    title: t("post.gettingHelp"),
+    question: t("post.whatNeed"),
+    }]
+  }
 
   const [showModal, setShowModal] = useState(true);
   const closeModal = () => (onClose ? onClose() : setShowModal(false));
@@ -63,21 +80,21 @@ const ModalComponent = ({
       >
         {currentPost
           ? tabs.map((tab) => (
-              <TabPane tab={tab.title} key={tab.key}>
-                <EditForm
-                  type={tab.key}
-                  textData={{ question: tab.question }}
-                  onClose={onClose}
-                  loadPost={loadPost}
-                  fullContent={fullContent}
-                  dispatchAction={dispatchAction}
-                  currentPost={currentPost}
-                  user={user}
-                  onSelect={handleEditPost}
-                  isAuthenticated={isAuthenticated}
-                  onCancel={handleCloseEditPost}
-                />
-              </TabPane>
+            <TabPane tab={tab.title}>
+            <EditForm
+              type={tab.key}
+              textData={{ question: tab.question }}
+              onClose={onClose}
+              loadPost={loadPost}
+              fullContent={fullContent}
+              dispatchAction={dispatchAction}
+              currentPost={currentPost}
+              user={user}
+              onSelect={handleEditPost}
+              isAuthenticated={isAuthenticated}
+              onCancel={handleCloseEditPost}
+            />
+          </TabPane>
             ))
           : tabs.map((tab) => (
               <TabPane

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import Zendesk, { ZendeskAPI } from "react-zendesk";
 import { NavBar } from "antd-mobile";
 import { Link, NavLink } from "react-router-dom";
 import styled from "styled-components";
@@ -155,7 +156,7 @@ const Header = ({
   setOrganisationId,
   webSocket,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { rooms } = webSocket;
 
   const index = localStorage.getItem("organisationId");
@@ -190,8 +191,13 @@ const Header = ({
     );
   };
 
+  useEffect(() => {
+    ZendeskAPI("webWidget", "setLocale", i18n.language);
+  }, [i18n.language]);
+
   return (
     <HeaderWrapper className="header">
+      <Zendesk zendeskKey={"95ac876b-8717-438b-ac57-7a2239714c9b"} />
       <StyledNavBar
         mode="light"
         leftContent={

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -192,7 +192,7 @@ const Header = ({
   };
 
   useEffect(() => {
-    ZendeskAPI("webWidget", "setLocale", i18n.language);
+    ZendeskAPI("webWidget", "setLocale", `${i18n.language}`);
   }, [i18n.language]);
 
   return (


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
<p>Added dynamic Zendesk widget via the <strong>react-zendesk npm package</strong>. It correctly passes the user language value to the api. </p>

<h2>Furthermore</h2>
<p>I have removed the merge between the 2127 and 2126 branches this branch only contains the fix for 2126.
<br /><strong> The user defined options do not change in the menu but the 'support' and header of the menu change to user defined langauge </strong></p>

_Please be concise and link any related issue(s):_
#2126
