### PR TITLE
linkify only on post details page

### DIFF
--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -122,6 +122,7 @@ const Post = ({
   isHidden,
   onPostHide,
   onPostUnhide,
+  linkifyText,
 }) => {
   const { t } = useTranslation();
   const { postId } = useParams();
@@ -637,7 +638,7 @@ const Post = ({
             </div>
             <WhiteSpace size="md" />
             {renderTags}
-            {renderContent(title, content, highlightWords, showComplete)}
+            {renderContent(title, content, highlightWords, showComplete, linkifyText)}
             {fullPostLength > CONTENT_LENGTH ? (
               <RenderViewMore />
             ) : (
@@ -778,7 +779,7 @@ const Post = ({
                     },
                   }}
                 >
-                  {renderContent(title, content, highlightWords, showComplete)}
+                  {renderContent(title, content, highlightWords, showComplete, linkifyText)}
                 </Link>
               ) : (
                 <>
@@ -792,7 +793,7 @@ const Post = ({
                       style={{ display: "none" }}
                     ></Link>
                   )}
-                  {renderContent(title, content, highlightWords, showComplete)}
+                  {renderContent(title, content, highlightWords, showComplete, linkifyText)}
                 </>
               )}
               {fullPostLength > CONTENT_LENGTH ||
@@ -842,7 +843,7 @@ const Post = ({
     </>
   );
 };
-const renderContent = (title, content, highlightWords, showComplete) => {
+const renderContent = (title, content, highlightWords, showComplete, linkifyText) => {
   let finalContent = content;
   if (finalContent.length > CONTENT_LENGTH && !showComplete) {
     finalContent = `${finalContent.substring(0, CONTENT_LENGTH)} . . .`;
@@ -850,10 +851,18 @@ const renderContent = (title, content, highlightWords, showComplete) => {
   return (
     <Card.Body className="content-wrapper">
       <Heading level={4} className="h4">
-        <Highlight textObj={linkify(title)} highlight={highlightWords} />
+      {
+        linkifyText ? <Highlight textObj={linkify(title)} highlight={highlightWords} /> :
+        <Highlight textObj={title} highlight={highlightWords} />
+      }
+
       </Heading>
       <p className="post-description">
-        <Highlight textObj={linkify(finalContent)} highlight={highlightWords} />
+        {linkifyText ?
+          <Highlight textObj={linkify(finalContent)} highlight={highlightWords} />
+          :
+          <Highlight textObj={finalContent} highlight={highlightWords} />
+        }
       </p>
     </Card.Body>
   );

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -851,18 +851,10 @@ const renderContent = (title, content, highlightWords, showComplete, linkifyText
   return (
     <Card.Body className="content-wrapper">
       <Heading level={4} className="h4">
-      {
-        linkifyText ? <Highlight textObj={linkify(title)} highlight={highlightWords} /> :
-        <Highlight textObj={title} highlight={highlightWords} />
-      }
-
+        <Highlight textObj={linkifyText ? linkify(title): title} highlight={highlightWords} />
       </Heading>
       <p className="post-description">
-        {linkifyText ?
-          <Highlight textObj={linkify(finalContent)} highlight={highlightWords} />
-          :
-          <Highlight textObj={finalContent} highlight={highlightWords} />
-        }
+        <Highlight textObj={linkifyText ? linkify(finalContent) : finalContent} highlight={highlightWords} />
       </p>
     </Card.Body>
   );

--- a/client/src/components/Feed/Post.js
+++ b/client/src/components/Feed/Post.js
@@ -122,7 +122,7 @@ const Post = ({
   isHidden,
   onPostHide,
   onPostUnhide,
-  linkifyText,
+  convertTextToURL,
 }) => {
   const { t } = useTranslation();
   const { postId } = useParams();
@@ -638,7 +638,7 @@ const Post = ({
             </div>
             <WhiteSpace size="md" />
             {renderTags}
-            {renderContent(title, content, highlightWords, showComplete, linkifyText)}
+            {renderContent(title, content, highlightWords, showComplete, convertTextToURL)}
             {fullPostLength > CONTENT_LENGTH ? (
               <RenderViewMore />
             ) : (
@@ -779,7 +779,7 @@ const Post = ({
                     },
                   }}
                 >
-                  {renderContent(title, content, highlightWords, showComplete, linkifyText)}
+                  {renderContent(title, content, highlightWords, showComplete, convertTextToURL)}
                 </Link>
               ) : (
                 <>
@@ -793,7 +793,7 @@ const Post = ({
                       style={{ display: "none" }}
                     ></Link>
                   )}
-                  {renderContent(title, content, highlightWords, showComplete, linkifyText)}
+                  {renderContent(title, content, highlightWords, showComplete, convertTextToURL)}
                 </>
               )}
               {fullPostLength > CONTENT_LENGTH ||
@@ -843,7 +843,7 @@ const Post = ({
     </>
   );
 };
-const renderContent = (title, content, highlightWords, showComplete, linkifyText) => {
+const renderContent = (title, content, highlightWords, showComplete, convertTextToURL) => {
   let finalContent = content;
   if (finalContent.length > CONTENT_LENGTH && !showComplete) {
     finalContent = `${finalContent.substring(0, CONTENT_LENGTH)} . . .`;
@@ -851,10 +851,10 @@ const renderContent = (title, content, highlightWords, showComplete, linkifyText
   return (
     <Card.Body className="content-wrapper">
       <Heading level={4} className="h4">
-        <Highlight textObj={linkifyText ? linkify(title): title} highlight={highlightWords} />
+        <Highlight textObj={convertTextToURL ? linkify(title): title} highlight={highlightWords} />
       </Heading>
       <p className="post-description">
-        <Highlight textObj={linkifyText ? linkify(finalContent) : finalContent} highlight={highlightWords} />
+        <Highlight textObj={convertTextToURL ? linkify(finalContent) : finalContent} highlight={highlightWords} />
       </p>
     </Card.Body>
   );

--- a/client/src/components/Feed/Posts.js
+++ b/client/src/components/Feed/Posts.js
@@ -126,6 +126,7 @@ const Posts = ({
               isHidden={hiddenPosts[posts[index][1]?._id]}
               onPostHide={hidePost}
               onPostUnhide={unhidePost}
+              linkifyText={false}
             />
             <HorizontalRule />
           </>

--- a/client/src/components/Feed/Posts.js
+++ b/client/src/components/Feed/Posts.js
@@ -126,7 +126,7 @@ const Posts = ({
               isHidden={hiddenPosts[posts[index][1]?._id]}
               onPostHide={hidePost}
               onPostUnhide={unhidePost}
-              linkifyText={false}
+              convertTextToURL={false}
             />
             <HorizontalRule />
           </>

--- a/client/src/components/Inbox/OrgPost.js
+++ b/client/src/components/Inbox/OrgPost.js
@@ -55,7 +55,7 @@ const Post = styled.div`
 export const OrgPost = ({ postRef }) => {
   const { t } = useTranslation();
   return (
-    <Post>
+    <Post convertTextToURL={false} >
       <header>
         <div className="post-type">{t(`feed.${postRef.objective}`)}</div>
         <span>.</span>

--- a/client/src/components/Profile/Activity.js
+++ b/client/src/components/Profile/Activity.js
@@ -82,6 +82,7 @@ const Activity = ({
             isHidden={hiddenPosts[posts[index][1]?._id]}
             onPostHide={hidePost}
             onPostUnhide={unhidePost}
+            convertTextToURL={false}
           />
         );
       }

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -319,7 +319,7 @@ const PostPage = ({ user, updateComments, isAuthenticated }) => {
                 updateComments={updateComments}
                 fullPostLength={postLength}
                 user={user}
-                linkifyText={true}
+                convertTextToURL={true}
               />
               <EditPost
                 user={user}

--- a/client/src/pages/PostPage.js
+++ b/client/src/pages/PostPage.js
@@ -319,6 +319,7 @@ const PostPage = ({ user, updateComments, isAuthenticated }) => {
                 updateComments={updateComments}
                 fullPostLength={postLength}
                 user={user}
+                linkifyText={true}
               />
               <EditPost
                 user={user}


### PR DESCRIPTION
### What does this pull request aim to achieve? 💯
convert text to url only when on post details page. If we are on helpborad(i.e. feed/posts) page, it should only be displayed as plain text.

_Please be concise and link any related issue(s):_ Resolves issue #2153 

<!--### 🚨Before submitting this pull request🚨:-->

<!--_Please do **NOT** submit this PR if you have not done the following:_-->

- [x] I have checked that no one else is working on similar changes.
- [ ] I have read the latest [**README**](README.md) and understand the development workflow.
- [x] The name of this branch is: **`feature/<branch_name>`**, or **`hotfix/<branch_name>`** if this is a hotfix, where `<branch_name>` briefly describes the issue(s) resolved and is prefixed with the issue number(s) (e.g. `1127-1130-update-git-branching-model`). The branch is created in a cloned version of this repo, **not a forked repo**.
- [x] This branch is rebased/merged with the **latest staging** (or the **latest production** if it is a hotfix).
- [x] There are no merge conflicts.
- [x] There are no console warnings and errors.
- [x] On the right hand side of this PR, I have linked the appropriate issue(s) under "Issues" and added a project progress under "Projects".
- [x] The title describes the issue(s) being addressed using format: **`<issue_numbers> - <brief_issue_description>`** (e.g. `#1127/#1130 - Update Git Branching Model`)
