### PR TITLE
changed styles for support button

### DIFF
--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -131,8 +131,13 @@ a {
   z-index: 1 !important;
   @media screen and (max-width: ${mq.tablet.wide.minWidth}) {
     bottom: 1.85rem !important;
-    left: 0.5rem !important;
     transform: scale(0.95) !important;
+  }
+}
+
+#launcher{
+  @media screen and (max-width: ${mq.phone.wide.maxWidth}){
+    left: 0.5rem !important;
   }
 }
 `;


### PR DESCRIPTION
Fix issue with #2183 Where support button covers the filter button on the feed page.
I have changed the <strong>Global CSS</strong> rule that changes the location of the support button
It now goes to the left only when screen size 767px or the <strong>phone max width</strong> is achieved.


_Please be concise and link any related issue(s):_
#2183 
