### PR TITLE
Feature/2192 organistation preformance issue

### DIFF
--- a/backend/lib/endpoints/organisations.js
+++ b/backend/lib/endpoints/organisations.js
@@ -24,7 +24,7 @@ async function routes(app) {
   const ORGS_PAGE_SIZE = 10;
 
   app.get(
-    "/",
+    "/" || "/search",
     {
       preValidation: [app.authenticateOptional],
       schema: searchOrganisationsSchema,

--- a/backend/lib/endpoints/organisations.js
+++ b/backend/lib/endpoints/organisations.js
@@ -24,7 +24,7 @@ async function routes(app) {
   const ORGS_PAGE_SIZE = 10;
 
   app.get(
-    "/" || "/search",
+    "/",
     {
       preValidation: [app.authenticateOptional],
       schema: searchOrganisationsSchema,

--- a/backend/lib/endpoints/organisations.js
+++ b/backend/lib/endpoints/organisations.js
@@ -24,7 +24,7 @@ async function routes(app) {
   const ORGS_PAGE_SIZE = 10;
 
   app.get(
-    "/search",
+    "/",
     {
       preValidation: [app.authenticateOptional],
       schema: searchOrganisationsSchema,
@@ -241,15 +241,6 @@ async function routes(app) {
       return { deletedOrganisation, success: true };
     },
   );
-
-  app.get("/", { schema: getOrganisationsSchema }, async (req) => {
-    const { ownerId } = req.params;
-    const filter = ownerId ? { ownerId } : {};
-    const sortedOrganisations = await Organisation.find(filter).sort({
-      name: 1,
-    });
-    return sortedOrganisations;
-  });
 
   app.get(
     "/:organisationId",

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -131,8 +131,13 @@ a {
   z-index: 1 !important;
   @media screen and (max-width: ${mq.tablet.wide.minWidth}) {
     bottom: 1.85rem !important;
-    left: 0.5rem !important;
     transform: scale(0.95) !important;
+  }
+}
+
+#launcher{
+  @media screen and (max-width: ${mq.phone.wide.maxWidth}){
+    left: 0.5rem !important;
   }
 }
 `;


### PR DESCRIPTION
<h2>Switched the original endpoint</h2>
<p>How does this make performance better?</p>
<ul>
<li>original endpoint returned all organizations which caused performance issue</li>
<li>the endpoint /search is now the default endpoint and returns up to 10 results unless limit is passed in the query string</li>
<li>as a result the endpoint now returns much quicker</li>
</ul>
<p>We can change the hard limit if desired (does not have to be 10)<p>
<br/>
<p><small>Since the endpoint "/search" is now "/" we should test this to make sure the default organization searches still work properly</small></p>
<br/>
_Please be concise and link any related issue(s):_
<br/>
&emsp;&emsp; >> #2192 