### PR TITLE
Resuable ProfileTabs component for use in profile redesign

### DIFF
--- a/client/src/components/Profile/ProfileTabs.js
+++ b/client/src/components/Profile/ProfileTabs.js
@@ -1,0 +1,42 @@
+import React from "react";
+import BasicTabs from "components/Tabs/BasicTabs";
+import styled from "styled-components";
+
+// Styled component named StyledButton
+const StyledTabs = styled.div`
+  .ant-tabs-ink-bar {
+    border-bottom: 2px solid #282828;
+    width: 200px;
+  }
+  .ant-tabs-tab-btn {
+    color: #939393;
+  }
+  .ant-tabs-tab-active > .ant-tabs-tab-btn {
+    font-family: Poppins;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 21px;
+    letter-spacing: 0px;
+    text-align: center;
+    color: #282828;
+  }
+  .ant-tabs-tab-disabled > .ant-tabs-tab-btn {
+    color: #e1e1e1;
+  }
+  .ant-tabs-nav-list {
+    margin: auto;
+    width: 90%;
+    display: flex;
+    justify-content: space-between;
+  }
+`;
+
+export default function ProfileTabs(props) {
+  // Use it like any other component.
+  return (
+    <StyledTabs>
+      <BasicTabs {...props} />
+    </StyledTabs>
+  );
+}

--- a/client/src/components/Profile/ProfileTabs.js
+++ b/client/src/components/Profile/ProfileTabs.js
@@ -26,9 +26,10 @@ const StyledTabs = styled.div`
   }
   .ant-tabs-nav-list {
     margin: auto;
-    width: 90%;
+    width: 800px;
     display: flex;
-    justify-content: space-between;
+    justify-content: space-around;
+    overflow: visible;
   }
 `;
 

--- a/client/src/components/Tabs/BasicTabs.js
+++ b/client/src/components/Tabs/BasicTabs.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import { Tabs } from "antd";
+
+const { TabPane } = Tabs;
+
+const BasicTabs = ({ callback, tabs, position, def, disabled }) => {
+  useEffect(() => {
+    console.log(tabs);
+  });
+
+  return (
+    <Tabs
+      tabPosition={position ? position : "top"}
+      defaultActiveKey={def ? def : "0"}
+      onChange={callback}
+    >
+      {tabs.map((e, index) => {
+        if (disabled) {
+          if (disabled[index] === true) {
+            return <TabPane tab={e} disabled key={index}></TabPane>;
+          } else {
+            return <TabPane tab={e} key={index}></TabPane>;
+          }
+        }
+        return <TabPane tab={e} key={index}></TabPane>;
+      })}
+    </Tabs>
+  );
+};
+
+export default BasicTabs;

--- a/client/src/locales/translations/en_US.json
+++ b/client/src/locales/translations/en_US.json
@@ -393,6 +393,13 @@
       "global": "Global",
       "editOrgAccount": "Edit Organization Account",
       "editOrgNotification": "Edit Organization Notification"
+    },
+    "views": {
+      "activity": "Activity",
+      "posts": "Posts",
+      "organizations": "Organizations",
+      "badges": "Badges",
+      "thanks": "Thanks"
     }
   },
   "auth": {

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -340,7 +340,7 @@ const Profile = ({
     }
   };
 
-  const tabsArray = [
+  const viewsArray = [
     t("profile.views.activity"),
     t("profile.views.posts"),
     t("profile.views.organizations"),
@@ -349,20 +349,7 @@ const Profile = ({
   ];
 
   const handleView = (key) => {
-    switch (key) {
-      case "0":
-        setView(tabsArray[0]);
-        break;
-      case "1":
-        setView(tabsArray[1]);
-        break;
-      case "2":
-        setView(tabsArray[2]);
-        break;
-      case "3":
-        setView(tabsArray[3]);
-        break;
-    }
+    setView(viewsArray[key]);
   };
 
   const emptyFeed = () => Object.keys(postsList).length < 1 && !isLoading;
@@ -457,10 +444,10 @@ const Profile = ({
         <div>
           <ProfileTabs
             callback={handleView}
-            tabs={["Activity", "Posts", "Thanks", "Badge"]}
+            tabs={viewsArray}
             position={"top"}
             def={"1"}
-            disabled={[true, false, true, true]}
+            disabled={[true, false, true, true, true]}
           />
           <SectionHeader>
             {isSelf

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -115,8 +115,8 @@ const Profile = ({
   const posts = useSelector(selectPosts);
   const [modal, setModal] = useState(false);
   const [drawer, setDrawer] = useState(false);
-  const [view, setView] = useState("posts");
   const { t } = useTranslation();
+  const [view, setView] = useState(t("profile.views.posts"));
   //react-virtualized loaded rows and row count.
   const [itemCount, setItemCount] = useState(0);
   const [toggleRefetch, setToggleRefetch] = useState(false);
@@ -340,19 +340,27 @@ const Profile = ({
     }
   };
 
+  const tabsArray = [
+    t("profile.views.activity"),
+    t("profile.views.posts"),
+    t("profile.views.organizations"),
+    t("profile.views.badges"),
+    t("profile.views.thanks"),
+  ];
+
   const handleView = (key) => {
     switch (key) {
       case "0":
-        setView("activity");
+        setView(tabsArray[0]);
         break;
       case "1":
-        setView("posts");
+        setView(tabsArray[1]);
         break;
       case "2":
-        setView("thanks");
+        setView(tabsArray[2]);
         break;
       case "3":
-        setView("badge");
+        setView(tabsArray[3]);
         break;
     }
   };

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -13,6 +13,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import Activity from "components/Profile/Activity";
+import ProfileTabs from "components/Profile/ProfileTabs";
 import CreatePost from "components/CreatePost/CreatePost";
 import ErrorAlert from "../components/Alert/ErrorAlert";
 import { FeedWrapper } from "components/Feed/FeedWrappers";
@@ -114,6 +115,7 @@ const Profile = ({
   const posts = useSelector(selectPosts);
   const [modal, setModal] = useState(false);
   const [drawer, setDrawer] = useState(false);
+  const [view, setView] = useState("posts");
   const { t } = useTranslation();
   //react-virtualized loaded rows and row count.
   const [itemCount, setItemCount] = useState(0);
@@ -338,6 +340,23 @@ const Profile = ({
     }
   };
 
+  const handleView = (key) => {
+    switch (key) {
+      case "0":
+        setView("activity");
+        break;
+      case "1":
+        setView("posts");
+        break;
+      case "2":
+        setView("thanks");
+        break;
+      case "3":
+        setView("badge");
+        break;
+    }
+  };
+
   const emptyFeed = () => Object.keys(postsList).length < 1 && !isLoading;
   const onToggleDrawer = () => setDrawer(!drawer);
   const onToggleCreatePostDrawer = () => setModal(!modal);
@@ -428,6 +447,13 @@ const Profile = ({
         )}
         <WhiteSpace />
         <div>
+          <ProfileTabs
+            callback={handleView}
+            tabs={["Activity", "Posts", "Thanks", "Badge"]}
+            position={"top"}
+            def={"1"}
+            disabled={[true, false, true, true]}
+          />
           <SectionHeader>
             {isSelf
               ? t("profile.individual.myActivity")


### PR DESCRIPTION
components\Profile\ProfileTabs.js is ready to be reviewed. This is the component that I am using to build the mobile version of the tabs to toggle between Activity, Posts, Thanks, Badge. This component will be used as the tabs for the cards in the profile component. You feed `<ProfileTabs /> `props to be how you need it below is a list of the props it is expecting and what it defaults to if nothing is specified. bolded props are required

- **callback** -> this is the callback function that will change your state so you can filter what component is being rendered
- **tabs** -> an array of the items you want to appear as tabs
- position -> where you want the tabs to render top, left, right, bottom. Defaults to top
- def -> which tab index position you want to be active by default
-  disabled -> an array of equal length to your tabs listing which ones are disabled (true) and which ones are active (false)

As an example for the profile view nav bars first I create my tabs
```
<ProfileTabs
            callback={handleView}
            tabs={["Activity", "Posts", "Thanks", "Badge"]}
            position={"top"}
            def={"1"}
            disabled={[true, false, true, true]}
          />
```
 I setup state for which content will be shown based on active tab
`const [view, setView] = useState("posts");`

I setup my callback to take in my index from the ProfileTabs component and alter my view state
```
const handleView = (key) => {
    switch (key) {
      case "0":
        setView("activity");
        break;
      case "1":
        setView("posts");
        break;
      case "2":
        setView("thanks");
        break;
      case "3":
        setView("badge");
        break;
    }
  };
```
