### PR TITLE
Feature/profile redesign menues

### DIFF
--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -265,4 +265,40 @@ export const DescriptionDesktop = styled.div`
   color: ${colors.darkerGray};
 `;
 
-export const MobileMenuWrapper = styled(Menu)``;
+export const MobileMenuWrapper = styled(Menu)`
+  &.ant-menu {
+    width: 100%;
+    background-color: transparent;
+    border-bottom: 1px solid #e0e0e0;
+    height: 4rem;
+    display: flex;
+    justify-content: space-between;
+    overflow: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  li.ant-menu-item {
+    margin: 0.8rem 0;
+    height: 3rem;
+    padding-bottom: 0rem;
+    overflow: visible;
+
+    color: ${theme.colors.darkerGray};
+    font-size: ${theme.typography.size.large};
+    line-height: 21px;
+    &:hover {
+      color: ${theme.colors.darkerGray};
+    }
+    text-align: center;
+  }
+
+  &.ant-menu .ant-menu-item-selected {
+    background-color: transparent;
+    border-bottom: 0.2rem solid ${theme.colors.black};
+    font-weight: bold;
+    overflow: visible;
+  }
+`;

--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -266,11 +266,14 @@ export const DescriptionDesktop = styled.div`
 `;
 
 export const MobileMenuWrapper = styled(Menu)`
+  &.ant-menu-vertical {
+    border-right: none;
+  }
   &.ant-menu {
     width: 100%;
     background-color: transparent;
     border-bottom: 1px solid #e0e0e0;
-    height: 4rem;
+    height: 4.5rem;
     display: flex;
     justify-content: space-between;
     overflow: auto;
@@ -300,5 +303,33 @@ export const MobileMenuWrapper = styled(Menu)`
     border-bottom: 0.2rem solid ${theme.colors.black};
     font-weight: bold;
     overflow: visible;
+  }
+`;
+export const DesktopMenuWrapper = styled(Menu)`
+  &.ant-menu-vertical {
+    border-right: none;
+  }
+  &.ant-menu {
+    background-color: transparent;
+    display: flex;
+    flex-direction: column;
+    padding-left: 0pt;
+  }
+  li.ant-menu-item {
+    margin: 0.8rem 0;
+    height: 3rem;
+    padding-bottom: 0rem;
+    text-align: left;
+    color: ${theme.colors.darkerGray};
+    font-size: ${theme.typography.size.large};
+    line-height: 21px;
+    &:hover {
+      color: ${theme.colors.darkerGray};
+    }
+  }
+
+  &.ant-menu .ant-menu-item-selected {
+    background-color: transparent;
+    font-weight: bold;
   }
 `;

--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -9,8 +9,6 @@ import { mq, theme } from "../../constants/theme";
 
 const { colors } = theme;
 
-const { SubMenu } = Menu;
-
 export const CustomDrawer = styled(Drawer)`
   .ant-drawer-content {
     border-top-left-radius: 1rem;
@@ -272,7 +270,7 @@ export const MobileMenuWrapper = styled(Menu)`
   &.ant-menu {
     width: 100%;
     background-color: transparent;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 0.063rem solid #e0e0e0;
     height: 4.5rem;
     display: flex;
     justify-content: space-between;
@@ -291,7 +289,7 @@ export const MobileMenuWrapper = styled(Menu)`
 
     color: ${theme.colors.darkerGray};
     font-size: ${theme.typography.size.large};
-    line-height: 21px;
+    line-height: 1.313rem;
     &:hover {
       color: ${theme.colors.darkerGray};
     }
@@ -313,7 +311,7 @@ export const DesktopMenuWrapper = styled(Menu)`
     background-color: transparent;
     display: flex;
     flex-direction: column;
-    padding-left: 0pt;
+    padding-left: 0rem;
   }
   li.ant-menu-item {
     margin: 0.8rem 0;
@@ -322,7 +320,7 @@ export const DesktopMenuWrapper = styled(Menu)`
     text-align: left;
     color: ${theme.colors.darkerGray};
     font-size: ${theme.typography.size.large};
-    line-height: 21px;
+    line-height: 1.313rem;
     &:hover {
       color: ${theme.colors.darkerGray};
     }

--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -1,4 +1,5 @@
-import { Drawer } from "antd";
+import { Drawer, Menu } from "antd";
+
 import styled from "styled-components";
 
 import Heading from "../Typography/Heading";
@@ -7,6 +8,8 @@ import TextLabel from "components/Typography/TextLabel";
 import { mq, theme } from "../../constants/theme";
 
 const { colors } = theme;
+
+const { SubMenu } = Menu;
 
 export const CustomDrawer = styled(Drawer)`
   .ant-drawer-content {
@@ -261,3 +264,5 @@ export const DescriptionDesktop = styled.div`
   line-height: 2rem;
   color: ${colors.darkerGray};
 `;
+
+export const MobileMenuWrapper = styled(Menu)``;

--- a/client/src/locales/translations/en_US.json
+++ b/client/src/locales/translations/en_US.json
@@ -401,7 +401,7 @@
       "badges": "Badges",
       "thanks": "Thanks",
       "requests": "Requests",
-      "offers": "offers"
+      "offers": "Offers"
     }
   },
   "auth": {

--- a/client/src/locales/translations/en_US.json
+++ b/client/src/locales/translations/en_US.json
@@ -399,7 +399,9 @@
       "posts": "Posts",
       "organizations": "Organizations",
       "badges": "Badges",
-      "thanks": "Thanks"
+      "thanks": "Thanks",
+      "requests": "Requests",
+      "offers": "offers"
     }
   },
   "auth": {

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -401,7 +401,6 @@ const Profile = ({
 
   const handleMenuToggle = (e) => {
     setSectionView(e.key);
-    console.log("click ", e);
   };
 
   return (

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -214,7 +214,7 @@ const Profile = ({
   };
   useEffect(() => {
     buildNavMenu();
-  }, [buildNavMenu, isSelf]); // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSelf]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -212,7 +212,7 @@ const Profile = ({
       setSectionView(t("profile.views.posts"));
     }
     setNavMenu(tempMenu);
-  }, [isSelf, loadMore, navMenu, t]);
+  }, [isSelf, loadMenu, navMenu, t]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -48,6 +48,7 @@ import {
   AvatarPhotoContainer,
   NamePara,
   MobileMenuWrapper,
+  DesktopMenuWrapper,
 } from "../components/Profile/ProfileComponents";
 import {
   FACEBOOK_URL,
@@ -597,6 +598,18 @@ const Profile = ({
             </Menu.Item>
           ))}
         </MobileMenuWrapper>
+        <DesktopMenuWrapper
+          defaultSelectedKeys={[sectionView]}
+          selectedKeys={sectionView}
+          onClick={handleMenuToggle}
+        >
+          {navMenu.map((item, index) => (
+            <Menu.Item key={item.name} disabled={item.disabled}>
+              {item.name}
+            </Menu.Item>
+          ))}
+        </DesktopMenuWrapper>
+
         {/* <ProfileTabs tabData={isSelfViews(tabViews, isSelf)} /> */}
         {isSelf && (
           <CustomDrawer

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -404,52 +404,6 @@ const Profile = ({
     console.log("click ", e);
   };
 
-  // const tabViews = {
-  //   defaultView: "1",
-  //   isSelf: isSelf,
-  //   position: window.width <= parseInt(mq.phone.wide.maxWidth) ? "top" : "left",
-  //   tabs: [
-  //     {
-  //       tabName: t("profile.views.activity"),
-  //       disabled: true,
-  //     },
-  //     {
-  //       tabName: t("profile.views.organizations"),
-  //       disabled: true,
-  //     },
-  //     {
-  //       tabName: t("profile.views.badges"),
-  //       disabled: true,
-  //     },
-  //     {
-  //       tabName: t("profile.views.thanks"),
-  //       disabled: true,
-  //     },
-  //   ],
-  // };
-  // const isSelfViews = (TabViews, isSelf) => {
-  //   if (isSelf) {
-  //     TabViews.tabs.splice(1, 0, {
-  //       tabName: t("requests"),
-  //       disabled: false,
-  //       tabView: `contents of requests`,
-  //     });
-  //     TabViews.tabs.splice(2, 0, {
-  //       tabName: t("offers"),
-  //       disabled: false,
-  //       tabView: `contents of offers`,
-  //     });
-  //   } else {
-  //     TabViews.tabs.splice(1, 0, {
-  //       tabName: t("profile.views.posts"),
-  //       disable: false,
-  //       showOthers: true,
-  //       tabView: (
-  //       ),
-  //     });
-  //   }
-  //   return TabViews;
-  // };
   return (
     <>
       <ProfileBackgroup />
@@ -531,18 +485,34 @@ const Profile = ({
           <Verification gtmPrefix={GTM.user.profilePrefix} />
         )}
         <WhiteSpace />
-        <MobileMenuWrapper
-          defaultSelectedKeys={[sectionView]}
-          selectedKeys={sectionView}
-          onClick={handleMenuToggle}
-        >
-          {navMenu.map((item, index) => (
-            <Menu.Item key={item.name} disabled={item.disabled}>
-              {item.name}
-            </Menu.Item>
-          ))}
-        </MobileMenuWrapper>
-        {sectionView === "posts" ? (
+        {window.width <= parseInt(mq.phone.wide.maxWidth) ? (
+          <MobileMenuWrapper
+            defaultSelectedKeys={[sectionView]}
+            selectedKeys={sectionView}
+            onClick={handleMenuToggle}
+          >
+            {navMenu.map((item, index) => (
+              <Menu.Item key={item.name} disabled={item.disabled}>
+                {item.name}
+              </Menu.Item>
+            ))}
+          </MobileMenuWrapper>
+        ) : null}
+        {window.width <= parseInt(mq.phone.wide.maxWidth) ? null : (
+          <DesktopMenuWrapper
+            defaultSelectedKeys={[sectionView]}
+            selectedKeys={sectionView}
+            onClick={handleMenuToggle}
+          >
+            {navMenu.map((item, index) => (
+              <Menu.Item key={item.name} disabled={item.disabled}>
+                {item.name}
+              </Menu.Item>
+            ))}
+          </DesktopMenuWrapper>
+        )}
+
+        {sectionView === "Posts" ? (
           <div>
             <SectionHeader>
               {isSelf
@@ -605,17 +575,6 @@ const Profile = ({
             </FeedWrapper>
           </div>
         ) : null}
-        <DesktopMenuWrapper
-          defaultSelectedKeys={[sectionView]}
-          selectedKeys={sectionView}
-          onClick={handleMenuToggle}
-        >
-          {navMenu.map((item, index) => (
-            <Menu.Item key={item.name} disabled={item.disabled}>
-              {item.name}
-            </Menu.Item>
-          ))}
-        </DesktopMenuWrapper>
 
         {/* <ProfileTabs tabData={isSelfViews(tabViews, isSelf)} /> */}
         {isSelf && (

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -214,7 +214,7 @@ const Profile = ({
   };
   useEffect(() => {
     buildNavMenu();
-  }, [buildNavMenu, isSelf]);
+  }, [buildNavMenu, isSelf]); // eslint-disable-next-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -130,24 +130,7 @@ const Profile = ({
   const { error, loading, user } = userProfileState;
   const [sectionView, setSectionView] = useState(t("requests"));
   const [loadMenu, setLoadMenu] = useState(true);
-  const [navMenu, setNavMenu] = useState([
-    {
-      name: t("profile.views.activity"),
-      disabled: true,
-    },
-    {
-      name: t("profile.views.organizations"),
-      disabled: true,
-    },
-    {
-      name: t("profile.views.badges"),
-      disabled: true,
-    },
-    {
-      name: t("profile.views.thanks"),
-      disabled: true,
-    },
-  ]);
+  const [navMenu, setNavMenu] = useState([]);
   const {
     id: userId,
     about,
@@ -191,28 +174,47 @@ const Profile = ({
   const getActorQuery = () => {
     return organisationId ? `&actorId=${organisationId}` : "";
   };
-
-  useEffect(() => {
-    const tempMenu = [...navMenu];
+  const buildNavMenu = () => {
+    const baseMenu = [
+      {
+        name: t("profile.views.activity"),
+        disabled: true,
+      },
+      {
+        name: t("profile.views.organizations"),
+        disabled: true,
+      },
+      {
+        name: t("profile.views.badges"),
+        disabled: true,
+      },
+      {
+        name: t("profile.views.thanks"),
+        disabled: true,
+      },
+    ];
     if (isSelf) {
-      tempMenu.splice(1, 0, {
+      baseMenu.splice(1, 0, {
         name: t("profile.views.requests"),
         disabled: false,
       });
-      tempMenu.splice(2, 0, {
+      baseMenu.splice(2, 0, {
         name: t("profile.views.offers"),
         disabled: false,
       });
       setSectionView(t("profile.views.requests"));
     } else {
-      tempMenu.splice(1, 0, {
+      baseMenu.splice(1, 0, {
         name: t("profile.views.posts"),
         disable: false,
       });
       setSectionView(t("profile.views.posts"));
     }
-    setNavMenu(tempMenu);
-  }, [isSelf, loadMenu, navMenu, t]);
+    setNavMenu(baseMenu);
+  };
+  useEffect(() => {
+    buildNavMenu();
+  }, [buildNavMenu, isSelf]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));
@@ -443,67 +445,6 @@ const Profile = ({
   //       disable: false,
   //       showOthers: true,
   //       tabView: (
-  //         <div>
-  //           <SectionHeader>
-  //             {isSelf
-  //               ? t("profile.individual.myActivity")
-  //               : t("profile.individual.userActivity")}
-  //             <PlaceholderIcon />
-  //             {isSelf && (
-  //               <>
-  //                 <CreatePostIcon
-  //                   id={GTM.user.profilePrefix + GTM.post.createPost}
-  //                   src={createPost}
-  //                   onClick={onToggleCreatePostDrawer}
-  //                 />
-  //                 <CreatePostButton
-  //                   onClick={onToggleCreatePostDrawer}
-  //                   id={GTM.user.profilePrefix + GTM.post.createPost}
-  //                   inline={true}
-  //                   icon={<PlusIcon />}
-  //                 >
-  //                   {t("post.create")}
-  //                 </CreatePostButton>
-  //               </>
-  //             )}
-  //           </SectionHeader>
-  //           <FeedWrapper isProfile>
-  //             <Activity
-  //               postDispatch={dispatch}
-  //               filteredPosts={postsList}
-  //               user={user}
-  //               postDelete={postDelete}
-  //               handlePostDelete={handlePostDelete}
-  //               handleEditPost={handleEditPost}
-  //               deleteModalVisibility={deleteModalVisibility}
-  //               handleCancelPostDelete={handleCancelPostDelete}
-  //               loadNextPage={loadNextPage}
-  //               isNextPageLoading={isLoading}
-  //               itemCount={itemCount}
-  //               isItemLoaded={isItemLoaded}
-  //               hasNextPage={loadMore}
-  //               totalPostCount={totalPostCount}
-  //             />
-  //             {postsError && (
-  //               <ErrorAlert
-  //                 message={t([
-  //                   `error.${postsError.message}`,
-  //                   `error.http.${postsError.message}`,
-  //                 ])}
-  //               />
-  //             )}
-  //             {emptyFeed() && <></>}
-  //             {isSelf && (
-  //               <CreatePost
-  //                 onCancel={onToggleCreatePostDrawer}
-  //                 loadPosts={refetchPosts}
-  //                 visible={modal}
-  //                 user={user}
-  //                 gtmPrefix={GTM.user.profilePrefix}
-  //               />
-  //             )}
-  //           </FeedWrapper>
-  //         </div>
   //       ),
   //     });
   //   }
@@ -601,6 +542,69 @@ const Profile = ({
             </Menu.Item>
           ))}
         </MobileMenuWrapper>
+        {sectionView === "posts" ? (
+          <div>
+            <SectionHeader>
+              {isSelf
+                ? t("profile.individual.myActivity")
+                : t("profile.individual.userActivity")}
+              <PlaceholderIcon />
+              {isSelf && (
+                <>
+                  <CreatePostIcon
+                    id={GTM.user.profilePrefix + GTM.post.createPost}
+                    src={createPost}
+                    onClick={onToggleCreatePostDrawer}
+                  />
+                  <CreatePostButton
+                    onClick={onToggleCreatePostDrawer}
+                    id={GTM.user.profilePrefix + GTM.post.createPost}
+                    inline={true}
+                    icon={<PlusIcon />}
+                  >
+                    {t("post.create")}
+                  </CreatePostButton>
+                </>
+              )}
+            </SectionHeader>
+            <FeedWrapper isProfile>
+              <Activity
+                postDispatch={dispatch}
+                filteredPosts={postsList}
+                user={user}
+                postDelete={postDelete}
+                handlePostDelete={handlePostDelete}
+                handleEditPost={handleEditPost}
+                deleteModalVisibility={deleteModalVisibility}
+                handleCancelPostDelete={handleCancelPostDelete}
+                loadNextPage={loadNextPage}
+                isNextPageLoading={isLoading}
+                itemCount={itemCount}
+                isItemLoaded={isItemLoaded}
+                hasNextPage={loadMore}
+                totalPostCount={totalPostCount}
+              />
+              {postsError && (
+                <ErrorAlert
+                  message={t([
+                    `error.${postsError.message}`,
+                    `error.http.${postsError.message}`,
+                  ])}
+                />
+              )}
+              {emptyFeed() && <></>}
+              {isSelf && (
+                <CreatePost
+                  onCancel={onToggleCreatePostDrawer}
+                  loadPosts={refetchPosts}
+                  visible={modal}
+                  user={user}
+                  gtmPrefix={GTM.user.profilePrefix}
+                />
+              )}
+            </FeedWrapper>
+          </div>
+        ) : null}
         <DesktopMenuWrapper
           defaultSelectedKeys={[sectionView]}
           selectedKeys={sectionView}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -212,7 +212,7 @@ const Profile = ({
       setSectionView(t("profile.views.posts"));
     }
     setNavMenu(tempMenu);
-  }, [isSelf, loadMenu, navMenu, t]);
+  }, [isSelf, loadMore, navMenu, t]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -46,6 +46,7 @@ import {
   PhotoUploadButton,
   AvatarPhotoContainer,
   NamePara,
+  MobileMenuWrapper,
 } from "../components/Profile/ProfileComponents";
 import {
   FACEBOOK_URL,
@@ -125,6 +126,25 @@ const Profile = ({
   const [toggleRefetch, setToggleRefetch] = useState(false);
   const [totalPostCount, setTotalPostCount] = useState(ARBITRARY_LARGE_NUM);
   const { error, loading, user } = userProfileState;
+  const [sectionView, setSectionView] = useState(t("requests"));
+  const [navMenu, setNavMenu] = useState([
+    {
+      name: t("profile.views.activity"),
+      disabled: true,
+    },
+    {
+      name: t("profile.views.organizations"),
+      disabled: true,
+    },
+    {
+      name: t("profile.views.badges"),
+      disabled: true,
+    },
+    {
+      name: t("profile.views.thanks"),
+      disabled: true,
+    },
+  ]);
   const {
     id: userId,
     about,
@@ -168,6 +188,26 @@ const Profile = ({
   const getActorQuery = () => {
     return organisationId ? `&actorId=${organisationId}` : "";
   };
+
+  useEffect(() => {
+    const tempMenu = [...navMenu];
+    if (isSelf) {
+      tempMenu.splice(1, 0, {
+        name: t("requests"),
+        disabled: false,
+      });
+      tempMenu.splice(2, 0, {
+        name: t("offers"),
+        disabled: false,
+      });
+    } else {
+      tempMenu.splice(1, 0, {
+        name: t("profile.views.posts"),
+        disable: false,
+      });
+    }
+    setNavMenu(tempMenu);
+  }, [isSelf, navMenu, t]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));
@@ -352,117 +392,117 @@ const Profile = ({
   }
   if (loading) return <Loader />;
 
-  const tabViews = {
-    defaultView: "1",
-    isSelf: isSelf,
-    position: window.width <= parseInt(mq.phone.wide.maxWidth) ? "top" : "left",
-    tabs: [
-      {
-        tabName: t("profile.views.activity"),
-        disabled: true,
-        tabView: `contents of activity`,
-      },
-      {
-        tabName: t("profile.views.organizations"),
-        disabled: true,
-        tabView: `contents of orgs`,
-      },
-      {
-        tabName: t("profile.views.badges"),
-        disabled: true,
-        tabView: `contents of badges`,
-      },
-      {
-        tabName: t("profile.views.thanks"),
-        disabled: true,
-        tabView: `contents of thanks`,
-      },
-    ],
+  const handleMenuToggle = (e) => {
+    console.log("click ", e);
   };
-  const isSelfViews = (TabViews, isSelf) => {
-    if (isSelf) {
-      TabViews.tabs.splice(1, 0, {
-        tabName: t("requests"),
-        disabled: false,
-        tabView: `contents of requests`,
-      });
-      TabViews.tabs.splice(2, 0, {
-        tabName: t("offers"),
-        disabled: false,
-        tabView: `contents of offers`,
-      });
-    } else {
-      TabViews.tabs.splice(1, 0, {
-        tabName: t("profile.views.posts"),
-        disable: false,
-        showOthers: true,
-        tabView: (
-          <div>
-            <SectionHeader>
-              {isSelf
-                ? t("profile.individual.myActivity")
-                : t("profile.individual.userActivity")}
-              <PlaceholderIcon />
-              {isSelf && (
-                <>
-                  <CreatePostIcon
-                    id={GTM.user.profilePrefix + GTM.post.createPost}
-                    src={createPost}
-                    onClick={onToggleCreatePostDrawer}
-                  />
-                  <CreatePostButton
-                    onClick={onToggleCreatePostDrawer}
-                    id={GTM.user.profilePrefix + GTM.post.createPost}
-                    inline={true}
-                    icon={<PlusIcon />}
-                  >
-                    {t("post.create")}
-                  </CreatePostButton>
-                </>
-              )}
-            </SectionHeader>
-            <FeedWrapper isProfile>
-              <Activity
-                postDispatch={dispatch}
-                filteredPosts={postsList}
-                user={user}
-                postDelete={postDelete}
-                handlePostDelete={handlePostDelete}
-                handleEditPost={handleEditPost}
-                deleteModalVisibility={deleteModalVisibility}
-                handleCancelPostDelete={handleCancelPostDelete}
-                loadNextPage={loadNextPage}
-                isNextPageLoading={isLoading}
-                itemCount={itemCount}
-                isItemLoaded={isItemLoaded}
-                hasNextPage={loadMore}
-                totalPostCount={totalPostCount}
-              />
-              {postsError && (
-                <ErrorAlert
-                  message={t([
-                    `error.${postsError.message}`,
-                    `error.http.${postsError.message}`,
-                  ])}
-                />
-              )}
-              {emptyFeed() && <></>}
-              {isSelf && (
-                <CreatePost
-                  onCancel={onToggleCreatePostDrawer}
-                  loadPosts={refetchPosts}
-                  visible={modal}
-                  user={user}
-                  gtmPrefix={GTM.user.profilePrefix}
-                />
-              )}
-            </FeedWrapper>
-          </div>
-        ),
-      });
-    }
-    return TabViews;
-  };
+
+  // const tabViews = {
+  //   defaultView: "1",
+  //   isSelf: isSelf,
+  //   position: window.width <= parseInt(mq.phone.wide.maxWidth) ? "top" : "left",
+  //   tabs: [
+  //     {
+  //       tabName: t("profile.views.activity"),
+  //       disabled: true,
+  //     },
+  //     {
+  //       tabName: t("profile.views.organizations"),
+  //       disabled: true,
+  //     },
+  //     {
+  //       tabName: t("profile.views.badges"),
+  //       disabled: true,
+  //     },
+  //     {
+  //       tabName: t("profile.views.thanks"),
+  //       disabled: true,
+  //     },
+  //   ],
+  // };
+  // const isSelfViews = (TabViews, isSelf) => {
+  //   if (isSelf) {
+  //     TabViews.tabs.splice(1, 0, {
+  //       tabName: t("requests"),
+  //       disabled: false,
+  //       tabView: `contents of requests`,
+  //     });
+  //     TabViews.tabs.splice(2, 0, {
+  //       tabName: t("offers"),
+  //       disabled: false,
+  //       tabView: `contents of offers`,
+  //     });
+  //   } else {
+  //     TabViews.tabs.splice(1, 0, {
+  //       tabName: t("profile.views.posts"),
+  //       disable: false,
+  //       showOthers: true,
+  //       tabView: (
+  //         <div>
+  //           <SectionHeader>
+  //             {isSelf
+  //               ? t("profile.individual.myActivity")
+  //               : t("profile.individual.userActivity")}
+  //             <PlaceholderIcon />
+  //             {isSelf && (
+  //               <>
+  //                 <CreatePostIcon
+  //                   id={GTM.user.profilePrefix + GTM.post.createPost}
+  //                   src={createPost}
+  //                   onClick={onToggleCreatePostDrawer}
+  //                 />
+  //                 <CreatePostButton
+  //                   onClick={onToggleCreatePostDrawer}
+  //                   id={GTM.user.profilePrefix + GTM.post.createPost}
+  //                   inline={true}
+  //                   icon={<PlusIcon />}
+  //                 >
+  //                   {t("post.create")}
+  //                 </CreatePostButton>
+  //               </>
+  //             )}
+  //           </SectionHeader>
+  //           <FeedWrapper isProfile>
+  //             <Activity
+  //               postDispatch={dispatch}
+  //               filteredPosts={postsList}
+  //               user={user}
+  //               postDelete={postDelete}
+  //               handlePostDelete={handlePostDelete}
+  //               handleEditPost={handleEditPost}
+  //               deleteModalVisibility={deleteModalVisibility}
+  //               handleCancelPostDelete={handleCancelPostDelete}
+  //               loadNextPage={loadNextPage}
+  //               isNextPageLoading={isLoading}
+  //               itemCount={itemCount}
+  //               isItemLoaded={isItemLoaded}
+  //               hasNextPage={loadMore}
+  //               totalPostCount={totalPostCount}
+  //             />
+  //             {postsError && (
+  //               <ErrorAlert
+  //                 message={t([
+  //                   `error.${postsError.message}`,
+  //                   `error.http.${postsError.message}`,
+  //                 ])}
+  //               />
+  //             )}
+  //             {emptyFeed() && <></>}
+  //             {isSelf && (
+  //               <CreatePost
+  //                 onCancel={onToggleCreatePostDrawer}
+  //                 loadPosts={refetchPosts}
+  //                 visible={modal}
+  //                 user={user}
+  //                 gtmPrefix={GTM.user.profilePrefix}
+  //               />
+  //             )}
+  //           </FeedWrapper>
+  //         </div>
+  //       ),
+  //     });
+  //   }
+  //   return TabViews;
+  // };
   return (
     <>
       <ProfileBackgroup />
@@ -544,7 +584,26 @@ const Profile = ({
           <Verification gtmPrefix={GTM.user.profilePrefix} />
         )}
         <WhiteSpace />
-        <ProfileTabs tabData={isSelfViews(tabViews, isSelf)} />
+        {/* <MobileMenuWrapper
+          defaultSelectedKeys={menuesItems[1]}
+          selectedKeys={viewSection}
+          onClick={handleMenuToggle}
+        >
+          {menu.map((item, index) => (
+            <Menu.Item key={item} id={gtmTag(gtmTagsMap[item])}>
+              {item.tabName}
+            </Menu.Item>
+          ))}
+          {isAuthenticated && (
+            <StyledCheckbox
+              checked={!ignoreUserLocation}
+              onChange={toggleShowNearMe}
+            >
+              {t("feed.filters.postsNearMe")}
+            </StyledCheckbox>
+          )}
+        </MobileMenuWrapper> */}
+        {/* <ProfileTabs tabData={isSelfViews(tabViews, isSelf)} /> */}
         {isSelf && (
           <CustomDrawer
             placement="bottom"

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -1,4 +1,5 @@
 import { WhiteSpace } from "antd-mobile";
+import { Menu } from "antd";
 import axios from "axios";
 import React, {
   useContext,
@@ -393,6 +394,7 @@ const Profile = ({
   if (loading) return <Loader />;
 
   const handleMenuToggle = (e) => {
+    setSectionView(e.key);
     console.log("click ", e);
   };
 
@@ -584,25 +586,17 @@ const Profile = ({
           <Verification gtmPrefix={GTM.user.profilePrefix} />
         )}
         <WhiteSpace />
-        {/* <MobileMenuWrapper
-          defaultSelectedKeys={menuesItems[1]}
-          selectedKeys={viewSection}
+        <MobileMenuWrapper
+          defaultSelectedKeys={[sectionView]}
+          selectedKeys={sectionView}
           onClick={handleMenuToggle}
         >
-          {menu.map((item, index) => (
-            <Menu.Item key={item} id={gtmTag(gtmTagsMap[item])}>
-              {item.tabName}
+          {navMenu.map((item, index) => (
+            <Menu.Item key={item.name} disabled={item.disabled}>
+              {item.name}
             </Menu.Item>
           ))}
-          {isAuthenticated && (
-            <StyledCheckbox
-              checked={!ignoreUserLocation}
-              onChange={toggleShowNearMe}
-            >
-              {t("feed.filters.postsNearMe")}
-            </StyledCheckbox>
-          )}
-        </MobileMenuWrapper> */}
+        </MobileMenuWrapper>
         {/* <ProfileTabs tabData={isSelfViews(tabViews, isSelf)} /> */}
         {isSelf && (
           <CustomDrawer

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -129,6 +129,7 @@ const Profile = ({
   const [totalPostCount, setTotalPostCount] = useState(ARBITRARY_LARGE_NUM);
   const { error, loading, user } = userProfileState;
   const [sectionView, setSectionView] = useState(t("requests"));
+  const [loadMenu, setLoadMenu] = useState(true);
   const [navMenu, setNavMenu] = useState([
     {
       name: t("profile.views.activity"),
@@ -191,29 +192,27 @@ const Profile = ({
     return organisationId ? `&actorId=${organisationId}` : "";
   };
 
-  const createMenu = () => {
+  useEffect(() => {
     const tempMenu = [...navMenu];
     if (isSelf) {
       tempMenu.splice(1, 0, {
-        name: t("requests"),
+        name: t("profile.views.requests"),
         disabled: false,
       });
       tempMenu.splice(2, 0, {
-        name: t("offers"),
+        name: t("profile.views.offers"),
         disabled: false,
       });
+      setSectionView(t("profile.views.requests"));
     } else {
       tempMenu.splice(1, 0, {
         name: t("profile.views.posts"),
         disable: false,
       });
+      setSectionView(t("profile.views.posts"));
     }
     setNavMenu(tempMenu);
-  };
-
-  useEffect(() => {
-    createMenu();
-  }, [createMenu]);
+  }, [isSelf, loadMenu, navMenu, t]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -191,7 +191,7 @@ const Profile = ({
     return organisationId ? `&actorId=${organisationId}` : "";
   };
 
-  useEffect(() => {
+  const createMenu = () => {
     const tempMenu = [...navMenu];
     if (isSelf) {
       tempMenu.splice(1, 0, {
@@ -209,7 +209,11 @@ const Profile = ({
       });
     }
     setNavMenu(tempMenu);
-  }, [isSelf, navMenu, t]);
+  };
+
+  useEffect(() => {
+    createMenu();
+  }, [createMenu]);
 
   useEffect(() => {
     dispatch(postsActions.resetPageAction({}));


### PR DESCRIPTION
### New option for navigating the section on the profile page using sectionView state instead of tabs

Created wrappers for the mobile (top nav) and desktop (side nav) version. Both are being displayed using a ternary operator that checks if the screen is mobile or not `window.width <= parseInt(mq.phone.wide.maxWidth)`

the menu onClick function takes in the value of the click and updates the sectionView state based off what you clicked on, this state will be used to hide/show your components

The mobile nav can probably stay where it is, but we will want to position the desktop wrapper once we are building the desktop view of things, ie we probably need a sidebar for it

![FightPandemics (4)](https://user-images.githubusercontent.com/5578094/109190416-ea2bf780-7749-11eb-94fe-35708dcb7437.gif)



