### PR TITLE
User Story 5.1 - See Org Book/Page Link #2273

### DIFF
--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -303,11 +303,15 @@ export const DescriptionDesktop = styled.div`
 
 export const SeeOrgBookLink = styled.a`
   color: ${colors.royalBlue};
+  width: 12rem;
+  height: 2rem;
   align-self: center;  
   display: block;
-  width: fit-content;
   margin: auto;
   margin-top: 1rem;
+  font-size: 1.6rem;
+  font-family: Poppins;
+  font-weight: 500;  
 `; 
 
 export const MobileLocation = styled.div`

--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -307,6 +307,7 @@ export const SeeOrgBookLink = styled.a`
   display: block;
   width: fit-content;
   margin: auto;
+  margin-top: 1rem;
 `; 
 
 export const MobileLocation = styled.div`

--- a/client/src/components/Profile/ProfileComponents.js
+++ b/client/src/components/Profile/ProfileComponents.js
@@ -300,6 +300,15 @@ export const DescriptionDesktop = styled.div`
     color: #282828;
   }
 `;
+
+export const SeeOrgBookLink = styled.a`
+  color: ${colors.royalBlue};
+  align-self: center;  
+  display: block;
+  width: fit-content;
+  margin: auto;
+`; 
+
 export const MobileLocation = styled.div`
   color: #939393;
   font-weight: normal;

--- a/client/src/pages/OrganisationProfile.js
+++ b/client/src/pages/OrganisationProfile.js
@@ -49,6 +49,7 @@ import {
   PlaceholderIcon,
   DescriptionDesktop,
   IconsContainer,
+  SeeOrgBookLink,
   SocialIcon,
   SectionHeader,
   CreatePostDiv,
@@ -494,6 +495,13 @@ const OrganisationProfile = ({ isAuthenticated }) => {
               {/* <IconsContainer>
                 <div className="social-icons">{renderURL()}</div>
               </IconsContainer> */}
+
+              {
+                isAuthenticated && !isOwner &&
+                (<SeeOrgBookLink>
+                  <a href="">See Org Book</a>
+                </SeeOrgBookLink>)
+              }
 
             </UserInfoDesktop>
           </UserInfoContainer>

--- a/client/src/pages/OrganisationProfile.js
+++ b/client/src/pages/OrganisationProfile.js
@@ -122,6 +122,7 @@ const URLS = {
 };
 
 const getHref = (url) => (url.startsWith("http") ? url : `//${url}`);
+const getOrgBookLink = (orgBookLink) => (orgBookLink.startsWith("http") ? orgBookLink : window.location.pathname + `/${orgBookLink}`);
 const PAGINATION_LIMIT = 10;
 const ARBITRARY_LARGE_NUM = 10000;
 const OrganisationProfile = ({ isAuthenticated }) => {
@@ -157,6 +158,7 @@ const OrganisationProfile = ({ isAuthenticated }) => {
     isOwner,
     urls = {},
     verified,
+    orgBookLink,
   } = organisation || {};
 
   const urlsAndEmail = { ...urls, email: isOwner ? null : email };
@@ -426,6 +428,16 @@ const OrganisationProfile = ({ isAuthenticated }) => {
     }
   };
 
+  const orgBookURL = () => {
+    if (organisation) {
+      if (orgBookLink) {
+        return getOrgBookLink(orgBookLink) ;
+      } else {
+        return;
+      }
+    }
+  };
+
   const emptyFeed = () => Object.keys(postsList).length < 1 && !isLoading;
   const onToggleDrawer = () => setDrawer(!drawer);
   const onToggleCreatePostDrawer = () => setModal(!modal);
@@ -497,9 +509,8 @@ const OrganisationProfile = ({ isAuthenticated }) => {
               </IconsContainer> */}
 
               {
-                isAuthenticated && !isOwner &&
                 (<SeeOrgBookLink>
-                  <a href="">See Org Book</a>
+                  <a href={orgBookURL()}  target="_blank">See Org Book</a>
                 </SeeOrgBookLink>)
               }
 


### PR DESCRIPTION
Resolves #2273 
- PR includes changes for User story 5.1
- Added ‘See Org Book' link underneath the org description
- Using the field 'orgBookLink' from the organization schema  as href value of the link
- added a method to check if the value of orgBookLink contains a complete url with http. If yes then use else append the string in the orgBookLink to the  window.location.pathname 